### PR TITLE
fix: delta_lohn immer 0.0 – lohn_median_chf als Spaltenname akzeptieren

### DIFF
--- a/src/scoring/ch_adjustments.py
+++ b/src/scoring/ch_adjustments.py
@@ -46,7 +46,8 @@ def apply_ch_adjustments(df: pd.DataFrame) -> pd.DataFrame:
     """
     CH-Faktoren auf Rohscores anwenden.
 
-    Erwartet Spalten: score_gesamt, branche, jahresbruttolohn (optional)
+    Erwartet Spalten: score_gesamt, branche
+    Optional: lohn_median_chf oder jahresbruttolohn (beide Spaltennamen akzeptiert)
     Gibt DataFrame mit score_ch (adjustierter Score) zurück.
     """
     df = df.copy()
@@ -54,9 +55,12 @@ def apply_ch_adjustments(df: pd.DataFrame) -> pd.DataFrame:
     # Brancheneffekt
     df["delta_branche"] = df["branche"].map(BRANCHENEFFEKTE).fillna(0.0)
 
-    # Lohneffekt (falls vorhanden)
-    if "jahresbruttolohn" in df.columns:
-        df["lohnklasse"] = df["jahresbruttolohn"].apply(classify_lohn)
+    # Lohneffekt — beide Spaltennamen akzeptieren (scores.csv: lohn_median_chf)
+    lohn_col = next(
+        (c for c in ["lohn_median_chf", "jahresbruttolohn"] if c in df.columns), None
+    )
+    if lohn_col:
+        df["lohnklasse"] = df[lohn_col].apply(classify_lohn)
         df["delta_lohn"] = df["lohnklasse"].map(LOHNEFFEKTE).fillna(0.0)
     else:
         df["delta_lohn"] = 0.0

--- a/tests/test_ch_adjustments.py
+++ b/tests/test_ch_adjustments.py
@@ -130,3 +130,25 @@ class TestApplyCHAdjustments:
         result = apply_ch_adjustments(df)
         assert "lohnklasse" in result.columns
         assert result["lohnklasse"].iloc[0] == "60k–100k CHF"
+
+    def test_mit_lohn_median_chf_spalte(self):
+        """lohn_median_chf (scores.csv-Spaltenname) wird korrekt verarbeitet."""
+        df = pd.DataFrame({
+            "branche": ["Finanzen"],
+            "lohn_median_chf": [160_000],
+            "score_gesamt": [5.0],
+        })
+        result = apply_ch_adjustments(df)
+        assert result["delta_lohn"].iloc[0] == LOHNEFFEKTE["> 150k CHF"]
+        assert result["score_ch"].iloc[0] > 5.0
+
+    def test_lohn_median_chf_hat_vorrang_vor_jahresbruttolohn(self):
+        """lohn_median_chf hat Vorrang wenn beide Spalten vorhanden."""
+        df = pd.DataFrame({
+            "branche": ["ICT"],
+            "lohn_median_chf": [200_000],   # > 150k → +0.4
+            "jahresbruttolohn": [50_000],    # < 60k  → -0.2
+            "score_gesamt": [5.0],
+        })
+        result = apply_ch_adjustments(df)
+        assert result["delta_lohn"].iloc[0] == LOHNEFFEKTE["> 150k CHF"]


### PR DESCRIPTION
## Problem

`ch_adjustments.py` prüfte nur auf `jahresbruttolohn`, aber `scores.csv` enthält `lohn_median_chf`. Dadurch war `delta_lohn` in der Produktion immer `0.0` — der Lohneffekt griff nie.

## Lösung

`apply_ch_adjustments()` akzeptiert jetzt beide Spaltennamen. `lohn_median_chf` hat Vorrang (entspricht dem tatsächlichen `scores.csv`-Schema), `jahresbruttolohn` als Fallback.

## Tests

- `test_mit_lohn_median_chf_spalte` — neuer Test für Produktionspfad
- `test_lohn_median_chf_hat_vorrang_vor_jahresbruttolohn` — Vorrang-Logik
- Coverage `ch_adjustments.py`: 100%

Closes #10