### PR TITLE
chore: pyproject.toml – pytest-Konfiguration, sys.path-Hacks entfernt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src/scoring", "src/data"]
+
+[tool.coverage.run]
+source = ["src/scoring"]
+omit = ["*/tests/*", "*/__pycache__/*"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/tests/test_adaptability.py
+++ b/tests/test_adaptability.py
@@ -1,12 +1,8 @@
 """Unit Tests für src/scoring/adaptability_scorer.py"""
 
-import sys
-from pathlib import Path
-
 import pandas as pd
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "src" / "scoring"))
 from adaptability_scorer import berechne_adaptabilitaet
 
 

--- a/tests/test_ch_adjustments.py
+++ b/tests/test_ch_adjustments.py
@@ -1,12 +1,8 @@
 """Unit Tests für src/scoring/ch_adjustments.py"""
 
-import sys
-from pathlib import Path
-
 import pandas as pd
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "src" / "scoring"))
 from ch_adjustments import apply_ch_adjustments, classify_lohn, BRANCHENEFFEKTE, LOHNEFFEKTE
 
 

--- a/tests/test_demo_scores.py
+++ b/tests/test_demo_scores.py
@@ -1,12 +1,8 @@
 """Unit Tests für src/scoring/generate_demo_scores.py"""
 
-import sys
-from pathlib import Path
-
 import pandas as pd
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "src" / "scoring"))
 from generate_demo_scores import apply_demo_scores, SCORE_LOOKUP
 
 

--- a/tests/test_exposure_scorer.py
+++ b/tests/test_exposure_scorer.py
@@ -4,15 +4,11 @@ Alle Anthropic-API-Calls werden gemockt — kein echter API-Key nötig.
 """
 
 import json
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pandas as pd
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "src" / "scoring"))
 from exposure_scorer import (
     SCORING_PROMPT,
     build_batch_requests,


### PR DESCRIPTION
## Was

- `pyproject.toml` mit `[tool.pytest.ini_options]` → `pythonpath = ["src/scoring"]`
- `[tool.coverage.run]` und `[tool.coverage.report]` mit `fail_under = 80`
- `sys.path.insert()`-Zeilen aus allen 4 Testdateien entfernt

## Warum

Die bisherigen `sys.path.insert()`-Hacks sind fragil und nicht idiomatisch. Mit `pyproject.toml` löst pytest den `src/scoring`-Pfad automatisch auf — sauberere Imports ohne Boilerplate.

Closes #12