### PR TITLE
docs: README ausbauen – Badges, Quickstart, Struktur, LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andreas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,21 +5,89 @@ colorFrom: red
 colorTo: gray
 sdk: docker
 pinned: false
+tags:
+  - streamlit
+  - labor-market
+  - ai-automation
+  - switzerland
+license: mit
 ---
 
-# KI-Jobexpositions-Analyse Schweiz
+# 🇨🇭 KI & Jobmarkt Schweiz
 
-Interaktive Webapp zur KI-Automatisierungsexposition von 204 Schweizer Berufen.
+[![CI](https://github.com/minigraphx/ki-jobexposition-schweiz/actions/workflows/ci.yml/badge.svg)](https://github.com/minigraphx/ki-jobexposition-schweiz/actions/workflows/ci.yml)
+[![HuggingFace Space](https://img.shields.io/badge/🤗%20HuggingFace-Live%20App-blue)](https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-Basierend auf amtlichen BFS-Daten (SAKE 2024) und ESCO-Berufsbeschreibungen werden
-KI-Expositions-Scores und Anpassungsfähigkeits-Scores für die grössten Schweizer
-Berufsgruppen berechnet und visualisiert.
+Interaktive Webapp zur KI-Automatisierungsexposition von **204 Schweizer Berufen** — basierend auf der Methodik von Andrej Karpathy, adaptiert für den Schweizer Arbeitsmarkt.
 
-**Seiten:**
-- 🗺️ Treemap — Alle Berufe nach Score und Beschäftigtenzahl
-- 📊 Matrix — Exposition × Anpassungsfähigkeit
-- 🏭 Branchen — Branchenvergleich und Konvergenz-Heatmap
-- 🔍 Berufssuche — Einzelberuf mit vollständiger Analyse
-- 📖 Methodik & Quellen
+**👉 [Live-App auf HuggingFace Spaces](https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz)**
 
-**Datenquellen:** BFS SAKE 2024 · ESCO v1.2 · BFS LSE 2022
+---
+
+## Seiten
+
+| Seite | Inhalt |
+|-------|--------|
+| 🗺️ Treemap | Alle 204 Berufe als Kacheln — Grösse = Beschäftigte, Farbe = KI-Score |
+| 📊 Matrix | Exposition × Anpassungsfähigkeit — vier Quadranten |
+| 🏭 Branchen | Branchenvergleich und Webb-Konvergenz-Heatmap |
+| 🔍 Berufssuche | Einzelberuf mit Radar-Chart und Permalink (`?beruf=…`) |
+| 📖 Methodik | Datenquellen, Scoring-Logik, Einschränkungen |
+
+## Methodik
+
+Für jeden Beruf bewertet **Claude (claude-sonnet-4-6)** fünf Kriterien (je 0–10):
+
+| Kriterium | Gewicht |
+|-----------|---------|
+| Digitaler Output | 25 % |
+| Wiederholbarkeit | 25 % |
+| Physische Präsenz | 20 % (negativ) |
+| Kreativität | 15 % (negativ) |
+| Soziale Interaktion | 15 % (negativ) |
+
+Auf den Rohscore werden **Schweiz-spezifische Anpassungen** angewendet (Branche, Lohnklasse). Datenquellen: BFS SAKE 2024 · ESCO v1.2 · BFS LSE 2022.
+
+## Lokale Entwicklung
+
+```bash
+# Repository klonen
+git clone https://github.com/minigraphx/ki-jobexposition-schweiz.git
+cd ki-jobexposition-schweiz
+
+# Virtuelle Umgebung & Abhängigkeiten
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+
+# App starten
+streamlit run src/app/app.py
+
+# Tests ausführen
+pytest tests/ -v --cov=src/scoring
+```
+
+## Projektstruktur
+
+```
+├── src/
+│   ├── app/              # Streamlit-App (6 Seiten)
+│   │   └── pages/
+│   ├── data/             # Datenpipeline (BFS, ESCO)
+│   └── scoring/          # KI-Scoring & CH-Anpassungen
+├── data/processed/       # Aufbereitete Daten (scores.csv)
+├── tests/                # pytest, Coverage ≥ 80 %
+├── Dockerfile            # HuggingFace Spaces Deployment
+└── requirements.txt      # Produktionsabhängigkeiten
+```
+
+## Datenquellen
+
+- **BFS SAKE 2024** — Beschäftigte und Frauenanteil pro Beruf
+- **ESCO v1.2** — Berufsbeschreibungen (Europäische Kommission)
+- **BFS LSE 2022** — Medianlöhne nach ISCO-Gruppe
+
+## Lizenz
+
+MIT — Details in [LICENSE](LICENSE).


### PR DESCRIPTION
## Was

- CI-Badge + HuggingFace-Badge + MIT-Badge
- Seiten-Tabelle, Methodik-Tabelle
- Quickstart (clone, venv, pip, streamlit run, pytest)
- Projektstruktur-Übersicht
- HuggingFace Space Tags (labor-market, ai-automation, switzerland, license: mit)
- `LICENSE` (MIT) neu hinzugefügt

Closes #13