### PR TITLE
ci: Auto-Deploy zu HuggingFace Spaces nach CI-Pass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy to HuggingFace
+
+on:
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Push to HuggingFace Spaces
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "GitHub Actions"
+          git push https://AndyWHV:${HF_TOKEN}@huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz main --force


### PR DESCRIPTION
## Was

`.github/workflows/deploy.yml` — wird ausgelöst wenn `CI` auf `main` erfolgreich abgeschlossen hat.

## Wie

- Trigger: `workflow_run` auf `CI`, Branch `main`, Conclusion `success`
- Push via HTTPS mit HuggingFace Token aus GitHub Secret `HF_TOKEN`
- Kein manuelles `git push hf main` mehr nötig

## Einmalige Einrichtung (manuell)

1. HuggingFace → Settings → Access Tokens → **New Token** (Write-Berechtigung)
2. GitHub → Repo Settings → Secrets → Actions → **New secret**
   - Name: `HF_TOKEN`
   - Value: der HF-Token

Closes #11