### PR TITLE
refactor: synchrones Scoring mit Hash-Delta und --force Flag

### DIFF
--- a/src/scoring/exposure_scorer.py
+++ b/src/scoring/exposure_scorer.py
@@ -1,26 +1,32 @@
 """
-KI-Expositions-Scoring via Claude Batch API (Karpathy-Methode, adaptiert für CH).
+KI-Expositions-Scoring via Claude API (Karpathy-Methode, adaptiert für CH).
 
-Verwendet die Message Batches API für asynchrone Verarbeitung aller Berufe in einem Aufruf.
-Günstiger als synchrone Calls und umgeht Mindestguthaben-Beschränkungen.
+Synchrone Verarbeitung mit Hash-basiertem Delta:
+  - Nur Berufe mit geänderter ESCO-Beschreibung werden neu gescort
+  - --force ohne Argument: alle Berufe neu scoren
+  - --force "Buchhalter/in": Beruf nach Name selektiv neu scoren
+  - --force 2411: alle Berufe mit diesem ISCO-Code-Präfix neu scoren
+  - Mehrere Argumente kombinierbar: --force "Arzt/Ärztin" 2411
 
-Für jeden Beruf wird ein Score 0–10 generiert basierend auf:
-- Digitaler Output (25%)
-- Wiederholbarkeit (25%)
-- Physische Präsenz (20%, negativ)
-- Kreativität (15%, negativ)
-- Soziale Interaktion (15%, negativ)
+Scoring-Kriterien je 0–10:
+  - Digitaler Output (25%)
+  - Wiederholbarkeit (25%)
+  - Physische Präsenz (20%, negativ)
+  - Kreativität (15%, negativ)
+  - Soziale Interaktion (15%, negativ)
 """
 
+import argparse
+import hashlib
 import json
 import logging
 import os
-import time
 from pathlib import Path
 
 import anthropic
 import pandas as pd
 from dotenv import load_dotenv
+from tqdm import tqdm
 
 load_dotenv()
 
@@ -28,10 +34,9 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 PROCESSED_DATA_PATH = Path(__file__).parent.parent.parent / "data" / "processed"
-BATCH_ID_FILE = PROCESSED_DATA_PATH / ".batch_id"
+SCORES_PATH = PROCESSED_DATA_PATH / "scores.csv"
 
 MODEL = "claude-sonnet-4-6"
-POLL_INTERVAL_SECONDS = 30
 
 SCORING_PROMPT = """Du bist ein Experte für den Arbeitsmarkt und KI-Automatisierung, spezialisiert auf den Schweizer Kontext.
 
@@ -62,59 +67,19 @@ Antworte NUR mit validem JSON in diesem Format:
 }}"""
 
 
-def build_batch_requests(jobs_df: pd.DataFrame) -> list[dict]:
-    """Batch-Requests für alle Berufe erstellen."""
-    requests = []
-    for idx, row in jobs_df.iterrows():
-        raw_beschreibung = row.get("esco_beschreibung", "")
-        beschreibung = (
-            raw_beschreibung
-            if raw_beschreibung and pd.notna(raw_beschreibung)
-            else "Keine Beschreibung verfügbar."
-        )
-        prompt = SCORING_PROMPT.format(beruf=row["beruf"], beschreibung=beschreibung)
-        requests.append({
-            "custom_id": str(idx),
-            "params": {
-                "model": MODEL,
-                "max_tokens": 512,
-                "messages": [{"role": "user", "content": prompt}],
-            },
-        })
-    return requests
+def compute_hash(beruf: str, beschreibung: str) -> str:
+    """SHA-256-Hash von Beruf + Beschreibung (erste 12 Zeichen)."""
+    return hashlib.sha256(f"{beruf}||{beschreibung}".encode()).hexdigest()[:12]
 
 
-def submit_batch(client: anthropic.Anthropic, jobs_df: pd.DataFrame) -> str:
-    """Batch einreichen und Batch-ID zurückgeben."""
-    requests = build_batch_requests(jobs_df)
-    logger.info(f"Sende Batch mit {len(requests)} Requests...")
-    batch = client.beta.messages.batches.create(requests=requests)
-    batch_id = batch.id
-    BATCH_ID_FILE.write_text(batch_id)
-    logger.info(f"Batch eingereicht: {batch_id}")
-    logger.info(f"Batch-ID gespeichert in {BATCH_ID_FILE} (für Resume bei Absturz)")
-    return batch_id
-
-
-def wait_for_batch(client: anthropic.Anthropic, batch_id: str) -> None:
-    """Warten bis Batch abgeschlossen ist."""
-    logger.info(f"Warte auf Batch {batch_id} (polling alle {POLL_INTERVAL_SECONDS}s)...")
-    while True:
-        batch = client.beta.messages.batches.retrieve(batch_id)
-        counts = batch.request_counts
-        logger.info(
-            f"Status: {batch.processing_status} | "
-            f"Fertig: {counts.succeeded} | "
-            f"Fehler: {counts.errored} | "
-            f"Ausstehend: {counts.processing}"
-        )
-        if batch.processing_status == "ended":
-            break
-        time.sleep(POLL_INTERVAL_SECONDS)
+def get_beschreibung(row: pd.Series) -> str:
+    """ESCO-Beschreibung aus Row lesen, mit Fallback bei fehlendem Wert."""
+    raw = row.get("esco_beschreibung", "")
+    return raw if (raw and pd.notna(raw)) else "Keine Beschreibung verfügbar."
 
 
 def parse_result(raw: str) -> dict:
-    """JSON aus API-Antwort extrahieren."""
+    """JSON aus API-Antwort extrahieren (mit Markdown-Code-Block-Fallback)."""
     if "```json" in raw:
         raw = raw.split("```json")[1].split("```")[0].strip()
     elif "```" in raw:
@@ -122,83 +87,182 @@ def parse_result(raw: str) -> dict:
     return json.loads(raw)
 
 
-def collect_results(client: anthropic.Anthropic, batch_id: str, jobs_df: pd.DataFrame) -> pd.DataFrame:
-    """Batch-Ergebnisse abrufen und mit jobs_df zusammenführen."""
-    scores = {}
-    failed = []
+def find_jobs_to_score(
+    jobs_df: pd.DataFrame,
+    scores_path: Path,
+    force: list[str] | None = None,
+) -> pd.DataFrame:
+    """
+    Jobs ermitteln die neu gescort werden müssen.
 
-    for result in client.beta.messages.batches.results(batch_id):
-        idx = int(result.custom_id)
-        beruf = jobs_df.loc[idx, "beruf"]
+    Args:
+        jobs_df:     Alle verfügbaren Berufe (mit esco_beschreibung).
+        scores_path: Pfad zur bestehenden scores.csv.
+        force:       None  → nur neue/geänderte Berufe (Hash-Delta)
+                     []    → alle Berufe
+                     [...] → Berufe nach Name (exact, case-insensitive) oder ISCO-Präfix
+    """
+    jobs_df = jobs_df.copy()
+    jobs_df["_hash"] = jobs_df.apply(
+        lambda r: compute_hash(r["beruf"], get_beschreibung(r)), axis=1
+    )
 
-        if result.result.type == "succeeded":
-            try:
-                data = parse_result(result.result.message.content[0].text)
-                data["beruf"] = beruf
-                scores[idx] = data
-            except json.JSONDecodeError as e:
-                logger.warning(f"Ungültiges JSON für '{beruf}': {e}")
-                failed.append(beruf)
+    # force=[] → alle neu scoren
+    if force is not None and len(force) == 0:
+        logger.info(f"--force: alle {len(jobs_df)} Berufe werden neu gescort.")
+        return jobs_df
+
+    # force=[term, ...] → selektiv nach Name oder ISCO-Präfix
+    if force:
+        mask = pd.Series(False, index=jobs_df.index)
+        for term in force:
+            if term.isdigit():
+                mask |= jobs_df["isco_code"].astype(str).str.startswith(term)
+            else:
+                mask |= jobs_df["beruf"].str.lower() == term.lower()
+        selected = jobs_df[mask]
+        if selected.empty:
+            logger.warning(f"--force: keine Übereinstimmung für {force}.")
         else:
-            logger.warning(f"Fehler für '{beruf}': {result.result.type}")
-            failed.append(beruf)
+            logger.info(
+                f"--force: {len(selected)} Beruf(e) selektiv neu gescort: "
+                f"{selected['beruf'].tolist()}"
+            )
+        return selected
+
+    # Kein force → Hash-Delta
+    if not scores_path.exists():
+        logger.info("Keine scores.csv gefunden — alle Berufe werden gescort.")
+        return jobs_df
+
+    existing = pd.read_csv(scores_path)
+    if "beschreibung_hash" not in existing.columns:
+        logger.info("Kein Hash in scores.csv vorhanden — alle Berufe werden gescort.")
+        return jobs_df
+
+    existing_hashes = dict(zip(existing["beruf"], existing["beschreibung_hash"]))
+    changed = jobs_df[
+        jobs_df.apply(
+            lambda r: existing_hashes.get(r["beruf"]) != r["_hash"], axis=1
+        )
+    ]
+
+    known = set(existing["beruf"])
+    n_new = (~changed["beruf"].isin(known)).sum()
+    n_changed = len(changed) - n_new
+    logger.info(
+        f"Delta: {n_new} neue, {n_changed} geänderte Berufe → {len(changed)} total."
+    )
+    return changed
+
+
+def score_single_job(client: anthropic.Anthropic, row: pd.Series) -> dict:
+    """Einen Beruf synchron via Claude API scoren."""
+    prompt = SCORING_PROMPT.format(
+        beruf=row["beruf"],
+        beschreibung=get_beschreibung(row),
+    )
+    response = client.messages.create(
+        model=MODEL,
+        max_tokens=512,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return parse_result(response.content[0].text)
+
+
+def score_changed_jobs(
+    jobs_df: pd.DataFrame,
+    scores_path: Path = SCORES_PATH,
+    force: list[str] | None = None,
+) -> pd.DataFrame:
+    """
+    Nur geänderte/neue Berufe scoren und Ergebnis mit bestehender scores.csv zusammenführen.
+
+    Returns:
+        Vollständiger DataFrame mit allen Berufen und aktualisierten Scores.
+    """
+    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+
+    to_score = find_jobs_to_score(jobs_df, scores_path, force)
+
+    if to_score.empty:
+        logger.info("Keine Änderungen erkannt — scores.csv bleibt unverändert.")
+        return pd.read_csv(scores_path) if scores_path.exists() else jobs_df.copy()
+
+    new_scores: list[dict] = []
+    failed: list[str] = []
+
+    for _, row in tqdm(to_score.iterrows(), total=len(to_score), desc="Scoring"):
+        try:
+            data = score_single_job(client, row)
+            data["beruf"] = row["beruf"]
+            data["beschreibung_hash"] = row["_hash"]
+            new_scores.append(data)
+        except Exception as e:
+            logger.warning(f"Fehler bei '{row['beruf']}': {e}")
+            failed.append(row["beruf"])
 
     if failed:
         logger.warning(f"{len(failed)} Berufe fehlgeschlagen: {', '.join(failed)}")
 
-    scores_df = pd.DataFrame(list(scores.values()))
-    merged = jobs_df.merge(scores_df, on="beruf", how="left")
-    logger.info(f"{len(scores)} von {len(jobs_df)} Berufen erfolgreich gescort.")
-    return merged
+    if not new_scores:
+        logger.error("Kein einziger Beruf erfolgreich gescort.")
+        return pd.read_csv(scores_path) if scores_path.exists() else jobs_df.copy()
+
+    scores_df = pd.DataFrame(new_scores)
+
+    # Basis-Spalten der neu gescorten Berufe mit den neuen Scores verbinden
+    scored_rows = (
+        to_score[to_score["beruf"].isin(scores_df["beruf"])]
+        .merge(scores_df, on="beruf")
+        .drop(columns=["_hash"], errors="ignore")
+    )
+
+    if scores_path.exists():
+        existing = pd.read_csv(scores_path)
+        # Alte Zeilen der neu gescorten Berufe ersetzen
+        kept = existing[~existing["beruf"].isin(scored_rows["beruf"])]
+        result = pd.concat([kept, scored_rows], ignore_index=True)
+    else:
+        result = scored_rows
+
+    logger.info(f"✓ {len(new_scores)} Berufe erfolgreich gescort.")
+    return result
 
 
-def score_all_jobs(jobs_df: pd.DataFrame, batch_id: str | None = None) -> pd.DataFrame:
-    """
-    Alle Berufe via Batch API scoren.
-
-    Wenn batch_id angegeben, wird ein laufender Batch weiterverfolgt (Resume).
-    """
-    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
-
-    if batch_id is None:
-        # Prüfen ob noch eine offene Batch-ID existiert
-        if BATCH_ID_FILE.exists():
-            saved_id = BATCH_ID_FILE.read_text().strip()
-            logger.info(f"Gefundene gespeicherte Batch-ID: {saved_id}")
-            logger.info("Verwende bestehenden Batch. Zum Neustart: .batch_id Datei löschen.")
-            batch_id = saved_id
-        else:
-            batch_id = submit_batch(client, jobs_df)
-
-    wait_for_batch(client, batch_id)
-    merged = collect_results(client, batch_id, jobs_df)
-
-    # Batch-ID löschen nach erfolgreichem Abschluss
-    if BATCH_ID_FILE.exists():
-        BATCH_ID_FILE.unlink()
-
-    return merged
-
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     import sys
     sys.path.insert(0, str(Path(__file__).parent))
     from ch_adjustments import apply_ch_adjustments
 
-    jobs_df = pd.read_csv(PROCESSED_DATA_PATH / "berufe_ch_esco.csv")
-    logger.info(f"Starte Batch-Scoring für {len(jobs_df)} Berufe...")
+    parser = argparse.ArgumentParser(
+        description="KI-Expositions-Scoring für Schweizer Berufe (nur Delta)."
+    )
+    parser.add_argument(
+        "--force",
+        nargs="*",
+        metavar="BERUF_ODER_ISCO",
+        help=(
+            "Ohne Argumente: alle Berufe neu scoren. "
+            "Mit Name(n) oder ISCO-Code(s): nur diese Berufe."
+        ),
+    )
+    args = parser.parse_args()
 
-    merged = score_all_jobs(jobs_df)
+    jobs_df = pd.read_csv(PROCESSED_DATA_PATH / "berufe_ch_esco_verified.csv")
+    logger.info(f"{len(jobs_df)} Berufe geladen.")
 
-    if "score_gesamt" not in merged.columns:
+    result = score_changed_jobs(jobs_df, scores_path=SCORES_PATH, force=args.force)
+
+    if "score_gesamt" not in result.columns:
         logger.error("Scoring fehlgeschlagen — scores.csv nicht aktualisiert.")
         raise SystemExit(1)
 
-    merged = apply_ch_adjustments(merged)
-    merged.to_csv(PROCESSED_DATA_PATH / "scores.csv", index=False)
-    logger.info(f"scores.csv gespeichert.")
+    result = apply_ch_adjustments(result)
+    result.to_csv(SCORES_PATH, index=False)
+    logger.info(f"scores.csv gespeichert ({len(result)} Berufe).")
 
-    print(f"\nTop 10 exponierte Berufe:")
-    print(merged.nlargest(10, "score_ch")[["beruf", "score_ch", "zeitrahmen"]].to_string())
-    print(f"\nTop 10 sicherste Berufe:")
-    print(merged.nsmallest(10, "score_ch")[["beruf", "score_ch", "zeitrahmen"]].to_string())
+    print("\nTop 10 exponierte Berufe:")
+    print(result.nlargest(10, "score_ch")[["beruf", "score_ch", "zeitrahmen"]].to_string())
+    print("\nTop 10 sicherste Berufe:")
+    print(result.nsmallest(10, "score_ch")[["beruf", "score_ch", "zeitrahmen"]].to_string())

--- a/tests/test_exposure_scorer.py
+++ b/tests/test_exposure_scorer.py
@@ -4,28 +4,30 @@ Alle Anthropic-API-Calls werden gemockt — kein echter API-Key nötig.
 """
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+
 from exposure_scorer import (
-    SCORING_PROMPT,
-    build_batch_requests,
-    collect_results,
+    compute_hash,
+    find_jobs_to_score,
+    get_beschreibung,
     parse_result,
-    score_all_jobs,
-    submit_batch,
-    wait_for_batch,
+    score_changed_jobs,
+    score_single_job,
 )
 
 
 # ── Fixtures ───────────────────────────────────────────────────────────────────
 
 @pytest.fixture
-def sample_jobs_df() -> pd.DataFrame:
+def jobs_df() -> pd.DataFrame:
     return pd.DataFrame({
         "beruf": ["Buchhalter/in", "Krankenpfleger/in"],
+        "isco_code": [2411, 2221],
         "esco_beschreibung": ["Erfasst Finanzdaten.", "Pflegt Patienten."],
     })
 
@@ -35,284 +37,260 @@ def mock_client() -> MagicMock:
     return MagicMock()
 
 
-def _make_score_payload(**overrides) -> dict:
+def _score_payload(**overrides) -> dict:
     base = {
-        "score_gesamt": 7.5,
-        "score_digital": 8.0,
-        "score_wiederholbarkeit": 7.0,
-        "score_physisch": 2.0,
-        "score_kreativitaet": 3.0,
-        "score_sozial": 2.0,
-        "haupt_risiko": "Automatisierung der Buchführung",
-        "zeitrahmen": "3-5 Jahre",
-        "begruendung": "Digitaler Beruf mit hoher Wiederholbarkeit.",
+        "score_gesamt": 7.5, "score_digital": 8.0,
+        "score_wiederholbarkeit": 7.0, "score_physisch": 2.0,
+        "score_kreativitaet": 3.0, "score_sozial": 2.0,
+        "haupt_risiko": "Automatisierung", "zeitrahmen": "3-5 Jahre",
+        "begruendung": "Digitaler Beruf.",
     }
     return {**base, **overrides}
+
+
+def _mock_response(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.content = [SimpleNamespace(text=json.dumps(payload))]
+    return resp
+
+
+# ── compute_hash ───────────────────────────────────────────────────────────────
+
+class TestComputeHash:
+    def test_gibt_string_zurueck(self):
+        assert isinstance(compute_hash("Buchhalter/in", "Finanzdaten"), str)
+
+    def test_laenge_12_zeichen(self):
+        assert len(compute_hash("Buchhalter/in", "Finanzdaten")) == 12
+
+    def test_gleiche_eingabe_gleicher_hash(self):
+        assert compute_hash("A", "B") == compute_hash("A", "B")
+
+    def test_unterschiedliche_beschreibung_anderer_hash(self):
+        assert compute_hash("A", "alt") != compute_hash("A", "neu")
+
+    def test_unterschiedlicher_beruf_anderer_hash(self):
+        assert compute_hash("Arzt", "X") != compute_hash("Ärztin", "X")
+
+
+# ── get_beschreibung ───────────────────────────────────────────────────────────
+
+class TestGetBeschreibung:
+    def test_gibt_beschreibung_zurueck(self):
+        row = pd.Series({"esco_beschreibung": "Meine Beschreibung"})
+        assert get_beschreibung(row) == "Meine Beschreibung"
+
+    def test_none_gibt_fallback(self):
+        row = pd.Series({"esco_beschreibung": None})
+        assert get_beschreibung(row) == "Keine Beschreibung verfügbar."
+
+    def test_nan_gibt_fallback(self):
+        row = pd.Series({"esco_beschreibung": float("nan")})
+        assert get_beschreibung(row) == "Keine Beschreibung verfügbar."
+
+    def test_fehlende_spalte_gibt_fallback(self):
+        row = pd.Series({"beruf": "Test"})
+        assert get_beschreibung(row) == "Keine Beschreibung verfügbar."
 
 
 # ── parse_result ───────────────────────────────────────────────────────────────
 
 class TestParseResult:
     def test_plain_json(self):
-        payload = _make_score_payload()
-        result = parse_result(json.dumps(payload))
-        assert result["score_gesamt"] == 7.5
+        assert parse_result(json.dumps(_score_payload()))["score_gesamt"] == 7.5
 
-    def test_json_in_markdown_json_block(self):
-        payload = _make_score_payload()
-        raw = f"```json\n{json.dumps(payload)}\n```"
-        result = parse_result(raw)
-        assert result["score_digital"] == 8.0
+    def test_markdown_json_block(self):
+        raw = f"```json\n{json.dumps(_score_payload())}\n```"
+        assert parse_result(raw)["score_digital"] == 8.0
 
-    def test_json_in_plain_code_block(self):
-        payload = _make_score_payload()
-        raw = f"```\n{json.dumps(payload)}\n```"
-        result = parse_result(raw)
-        assert result["zeitrahmen"] == "3-5 Jahre"
+    def test_plain_code_block(self):
+        raw = f"```\n{json.dumps(_score_payload())}\n```"
+        assert parse_result(raw)["zeitrahmen"] == "3-5 Jahre"
 
-    def test_invalid_json_raises(self):
+    def test_ungültiges_json_wirft_fehler(self):
         with pytest.raises(json.JSONDecodeError):
-            parse_result("das ist kein JSON")
-
-    def test_alle_felder_vorhanden(self):
-        payload = _make_score_payload()
-        result = parse_result(json.dumps(payload))
-        for key in ["score_gesamt", "score_digital", "score_wiederholbarkeit",
-                    "score_physisch", "score_kreativitaet", "score_sozial",
-                    "haupt_risiko", "zeitrahmen", "begruendung"]:
-            assert key in result
+            parse_result("kein json")
 
 
-# ── build_batch_requests ───────────────────────────────────────────────────────
+# ── find_jobs_to_score ─────────────────────────────────────────────────────────
 
-class TestBuildBatchRequests:
-    def test_anzahl_requests_stimmt(self, sample_jobs_df):
-        reqs = build_batch_requests(sample_jobs_df)
-        assert len(reqs) == 2
-
-    def test_custom_id_entspricht_index(self, sample_jobs_df):
-        reqs = build_batch_requests(sample_jobs_df)
-        ids = [int(r["custom_id"]) for r in reqs]
-        assert ids == list(sample_jobs_df.index)
-
-    def test_model_gesetzt(self, sample_jobs_df):
-        reqs = build_batch_requests(sample_jobs_df)
-        for req in reqs:
-            assert req["params"]["model"] == "claude-sonnet-4-6"
-
-    def test_max_tokens_gesetzt(self, sample_jobs_df):
-        reqs = build_batch_requests(sample_jobs_df)
-        for req in reqs:
-            assert req["params"]["max_tokens"] == 512
-
-    def test_beruf_im_prompt(self, sample_jobs_df):
-        reqs = build_batch_requests(sample_jobs_df)
-        assert "Buchhalter/in" in reqs[0]["params"]["messages"][0]["content"]
-        assert "Krankenpfleger/in" in reqs[1]["params"]["messages"][0]["content"]
-
-    def test_beschreibung_im_prompt(self, sample_jobs_df):
-        reqs = build_batch_requests(sample_jobs_df)
-        assert "Erfasst Finanzdaten." in reqs[0]["params"]["messages"][0]["content"]
-
-    def test_fehlende_beschreibung_fallback(self):
-        df = pd.DataFrame({
-            "beruf": ["Testberuf"],
-            "esco_beschreibung": [None],
-        })
-        reqs = build_batch_requests(df)
-        assert "Keine Beschreibung verfügbar." in reqs[0]["params"]["messages"][0]["content"]
-
-    def test_leerer_dataframe(self):
-        df = pd.DataFrame(columns=["beruf", "esco_beschreibung"])
-        reqs = build_batch_requests(df)
-        assert reqs == []
-
-    def test_message_rolle_ist_user(self, sample_jobs_df):
-        reqs = build_batch_requests(sample_jobs_df)
-        assert reqs[0]["params"]["messages"][0]["role"] == "user"
-
-
-# ── submit_batch ───────────────────────────────────────────────────────────────
-
-class TestSubmitBatch:
-    def test_gibt_batch_id_zurueck(self, sample_jobs_df, mock_client, tmp_path):
-        mock_client.beta.messages.batches.create.return_value = SimpleNamespace(id="batch_abc123")
-        with patch("exposure_scorer.BATCH_ID_FILE", tmp_path / ".batch_id"):
-            result = submit_batch(mock_client, sample_jobs_df)
-        assert result == "batch_abc123"
-
-    def test_schreibt_batch_id_in_datei(self, sample_jobs_df, mock_client, tmp_path):
-        mock_client.beta.messages.batches.create.return_value = SimpleNamespace(id="batch_xyz")
-        batch_id_file = tmp_path / ".batch_id"
-        with patch("exposure_scorer.BATCH_ID_FILE", batch_id_file):
-            submit_batch(mock_client, sample_jobs_df)
-        assert batch_id_file.read_text() == "batch_xyz"
-
-    def test_ruft_create_mit_requests_auf(self, sample_jobs_df, mock_client, tmp_path):
-        mock_client.beta.messages.batches.create.return_value = SimpleNamespace(id="b1")
-        with patch("exposure_scorer.BATCH_ID_FILE", tmp_path / ".batch_id"):
-            submit_batch(mock_client, sample_jobs_df)
-        mock_client.beta.messages.batches.create.assert_called_once()
-        kwargs = mock_client.beta.messages.batches.create.call_args
-        assert len(kwargs[1]["requests"]) == 2
-
-
-# ── wait_for_batch ─────────────────────────────────────────────────────────────
-
-class TestWaitForBatch:
-    def test_beendet_schleife_bei_ended(self, mock_client):
-        ended = SimpleNamespace(
-            processing_status="ended",
-            request_counts=SimpleNamespace(succeeded=2, errored=0, processing=0),
-        )
-        mock_client.beta.messages.batches.retrieve.return_value = ended
-        with patch("exposure_scorer.time.sleep") as mock_sleep:
-            wait_for_batch(mock_client, "batch_123")
-        mock_sleep.assert_not_called()
-
-    def test_pollt_bis_ended(self, mock_client):
-        processing = SimpleNamespace(
-            processing_status="in_progress",
-            request_counts=SimpleNamespace(succeeded=0, errored=0, processing=2),
-        )
-        ended = SimpleNamespace(
-            processing_status="ended",
-            request_counts=SimpleNamespace(succeeded=2, errored=0, processing=0),
-        )
-        mock_client.beta.messages.batches.retrieve.side_effect = [processing, processing, ended]
-        with patch("exposure_scorer.time.sleep"):
-            wait_for_batch(mock_client, "batch_123")
-        assert mock_client.beta.messages.batches.retrieve.call_count == 3
-
-
-# ── collect_results ────────────────────────────────────────────────────────────
-
-def _make_api_result(custom_id: str, beruf: str, payload: dict | None = None, failed: bool = False):
-    if failed:
-        return SimpleNamespace(
-            custom_id=custom_id,
-            result=SimpleNamespace(type="errored"),
-        )
-    text = json.dumps(payload or _make_score_payload())
-    return SimpleNamespace(
-        custom_id=custom_id,
-        result=SimpleNamespace(
-            type="succeeded",
-            message=SimpleNamespace(
-                content=[SimpleNamespace(text=text)]
-            ),
-        ),
-    )
-
-
-class TestCollectResults:
-    def test_merged_dataframe_hat_score_spalten(self, mock_client, sample_jobs_df):
-        results = [
-            _make_api_result("0", "Buchhalter/in"),
-            _make_api_result("1", "Krankenpfleger/in", _make_score_payload(score_gesamt=3.0)),
-        ]
-        mock_client.beta.messages.batches.results.return_value = iter(results)
-        merged = collect_results(mock_client, "batch_123", sample_jobs_df)
-        assert "score_gesamt" in merged.columns
-        assert len(merged) == 2
-
-    def test_fehlgeschlagene_results_werden_uebersprungen(self, mock_client, sample_jobs_df):
-        results = [
-            _make_api_result("0", "Buchhalter/in"),
-            _make_api_result("1", "Krankenpfleger/in", failed=True),
-        ]
-        mock_client.beta.messages.batches.results.return_value = iter(results)
-        merged = collect_results(mock_client, "batch_123", sample_jobs_df)
-        # Buchhalter hat Score, Krankenpfleger nicht (NaN nach left merge)
-        assert merged.loc[merged["beruf"] == "Buchhalter/in", "score_gesamt"].notna().all()
-
-    def test_ungültiges_json_wird_uebersprungen(self, mock_client, sample_jobs_df):
-        bad_result = SimpleNamespace(
-            custom_id="0",
-            result=SimpleNamespace(
-                type="succeeded",
-                message=SimpleNamespace(content=[SimpleNamespace(text="kein json!")]),
-            ),
-        )
-        good_result = _make_api_result("1", "Krankenpfleger/in")
-        mock_client.beta.messages.batches.results.return_value = iter([bad_result, good_result])
-        merged = collect_results(mock_client, "batch_123", sample_jobs_df)
-        assert len(merged) == 2  # left merge behält alle Zeilen
-
-
-# ── score_all_jobs ─────────────────────────────────────────────────────────────
-
-class TestScoreAllJobs:
-    def _setup_client_mock(self, mock_client, sample_jobs_df):
-        mock_client.beta.messages.batches.create.return_value = SimpleNamespace(id="batch_new")
-        mock_client.beta.messages.batches.retrieve.return_value = SimpleNamespace(
-            processing_status="ended",
-            request_counts=SimpleNamespace(succeeded=2, errored=0, processing=0),
-        )
-        api_results = [
-            _make_api_result("0", "Buchhalter/in"),
-            _make_api_result("1", "Krankenpfleger/in", _make_score_payload(score_gesamt=3.0)),
-        ]
-        mock_client.beta.messages.batches.results.return_value = iter(api_results)
-
-    def test_gibt_dataframe_mit_scores_zurueck(self, sample_jobs_df, tmp_path):
-        with patch("exposure_scorer.anthropic.Anthropic") as MockAnthropic, \
-             patch("exposure_scorer.BATCH_ID_FILE", tmp_path / ".batch_id"), \
-             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
-            mock_client = MagicMock()
-            MockAnthropic.return_value = mock_client
-            self._setup_client_mock(mock_client, sample_jobs_df)
-            result = score_all_jobs(sample_jobs_df)
-        assert "score_gesamt" in result.columns
+class TestFindJobsToScore:
+    def test_keine_scores_csv_gibt_alle_zurueck(self, jobs_df, tmp_path):
+        result = find_jobs_to_score(jobs_df, tmp_path / "scores.csv")
         assert len(result) == 2
 
-    def test_verwendet_gespeicherte_batch_id(self, sample_jobs_df, tmp_path):
-        batch_id_file = tmp_path / ".batch_id"
-        batch_id_file.write_text("batch_existing")
-        with patch("exposure_scorer.anthropic.Anthropic") as MockAnthropic, \
-             patch("exposure_scorer.BATCH_ID_FILE", batch_id_file), \
-             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
-            mock_client = MagicMock()
-            MockAnthropic.return_value = mock_client
-            mock_client.beta.messages.batches.retrieve.return_value = SimpleNamespace(
-                processing_status="ended",
-                request_counts=SimpleNamespace(succeeded=2, errored=0, processing=0),
-            )
-            api_results = [
-                _make_api_result("0", "Buchhalter/in"),
-                _make_api_result("1", "Krankenpfleger/in"),
-            ]
-            mock_client.beta.messages.batches.results.return_value = iter(api_results)
-            score_all_jobs(sample_jobs_df)
-        # create darf nicht aufgerufen worden sein
-        mock_client.beta.messages.batches.create.assert_not_called()
+    def test_kein_hash_in_csv_gibt_alle_zurueck(self, jobs_df, tmp_path):
+        scores_path = tmp_path / "scores.csv"
+        pd.DataFrame({"beruf": ["Buchhalter/in"]}).to_csv(scores_path, index=False)
+        result = find_jobs_to_score(jobs_df, scores_path)
+        assert len(result) == 2
 
-    def test_loescht_batch_id_datei_nach_abschluss(self, sample_jobs_df, tmp_path):
-        batch_id_file = tmp_path / ".batch_id"
-        with patch("exposure_scorer.anthropic.Anthropic") as MockAnthropic, \
-             patch("exposure_scorer.BATCH_ID_FILE", batch_id_file), \
-             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
-            mock_client = MagicMock()
-            MockAnthropic.return_value = mock_client
-            self._setup_client_mock(mock_client, sample_jobs_df)
-            score_all_jobs(sample_jobs_df)
-        assert not batch_id_file.exists()
+    def test_unveraenderte_hashes_geben_leeres_result(self, jobs_df, tmp_path):
+        scores_path = tmp_path / "scores.csv"
+        # Aktuelle Hashes in scores.csv schreiben
+        df = jobs_df.copy()
+        df["beschreibung_hash"] = df.apply(
+            lambda r: compute_hash(r["beruf"], r["esco_beschreibung"]), axis=1
+        )
+        df.to_csv(scores_path, index=False)
+        result = find_jobs_to_score(jobs_df, scores_path)
+        assert len(result) == 0
 
-    def test_explizite_batch_id_ueberspringt_submit(self, sample_jobs_df, tmp_path):
+    def test_geaenderte_beschreibung_wird_erkannt(self, jobs_df, tmp_path):
+        scores_path = tmp_path / "scores.csv"
+        df = jobs_df.copy()
+        df["beschreibung_hash"] = "alter_hash"
+        df.to_csv(scores_path, index=False)
+        result = find_jobs_to_score(jobs_df, scores_path)
+        assert len(result) == 2
+
+    def test_force_leer_gibt_alle_zurueck(self, jobs_df, tmp_path):
+        result = find_jobs_to_score(jobs_df, tmp_path / "scores.csv", force=[])
+        assert len(result) == 2
+
+    def test_force_nach_name(self, jobs_df, tmp_path):
+        result = find_jobs_to_score(
+            jobs_df, tmp_path / "scores.csv", force=["Buchhalter/in"]
+        )
+        assert len(result) == 1
+        assert result.iloc[0]["beruf"] == "Buchhalter/in"
+
+    def test_force_case_insensitive(self, jobs_df, tmp_path):
+        result = find_jobs_to_score(
+            jobs_df, tmp_path / "scores.csv", force=["buchhalter/in"]
+        )
+        assert len(result) == 1
+
+    def test_force_nach_isco_code(self, jobs_df, tmp_path):
+        result = find_jobs_to_score(
+            jobs_df, tmp_path / "scores.csv", force=["2411"]
+        )
+        assert len(result) == 1
+        assert result.iloc[0]["beruf"] == "Buchhalter/in"
+
+    def test_force_isco_praeffix(self, jobs_df, tmp_path):
+        """ISCO-Präfix '2' trifft beide Berufe (2411 und 2221)."""
+        result = find_jobs_to_score(
+            jobs_df, tmp_path / "scores.csv", force=["2"]
+        )
+        assert len(result) == 2
+
+    def test_force_unbekannter_term_gibt_leeres_result(self, jobs_df, tmp_path):
+        result = find_jobs_to_score(
+            jobs_df, tmp_path / "scores.csv", force=["Unbekannter Beruf"]
+        )
+        assert len(result) == 0
+
+    def test_hash_spalte_in_result(self, jobs_df, tmp_path):
+        result = find_jobs_to_score(jobs_df, tmp_path / "scores.csv")
+        assert "_hash" in result.columns
+
+
+# ── score_single_job ───────────────────────────────────────────────────────────
+
+class TestScoreSingleJob:
+    def test_gibt_dict_mit_scores_zurueck(self, jobs_df, mock_client):
+        row = jobs_df.iloc[0]
+        mock_client.messages.create.return_value = _mock_response(_score_payload())
+        result = score_single_job(mock_client, row)
+        assert result["score_gesamt"] == 7.5
+
+    def test_prompt_enthaelt_beruf(self, jobs_df, mock_client):
+        row = jobs_df.iloc[0]
+        mock_client.messages.create.return_value = _mock_response(_score_payload())
+        score_single_job(mock_client, row)
+        call_content = mock_client.messages.create.call_args[1]["messages"][0]["content"]
+        assert "Buchhalter/in" in call_content
+
+    def test_prompt_enthaelt_beschreibung(self, jobs_df, mock_client):
+        row = jobs_df.iloc[0]
+        mock_client.messages.create.return_value = _mock_response(_score_payload())
+        score_single_job(mock_client, row)
+        call_content = mock_client.messages.create.call_args[1]["messages"][0]["content"]
+        assert "Erfasst Finanzdaten." in call_content
+
+    def test_model_korrekt(self, jobs_df, mock_client):
+        row = jobs_df.iloc[0]
+        mock_client.messages.create.return_value = _mock_response(_score_payload())
+        score_single_job(mock_client, row)
+        assert mock_client.messages.create.call_args[1]["model"] == "claude-sonnet-4-6"
+
+
+# ── score_changed_jobs ─────────────────────────────────────────────────────────
+
+class TestScoreChangedJobs:
+    def _setup_mock(self, mock_client, payload=None):
+        mock_client.messages.create.return_value = _mock_response(payload or _score_payload())
+
+    def test_gibt_dataframe_mit_score_spalten(self, jobs_df, tmp_path):
         with patch("exposure_scorer.anthropic.Anthropic") as MockAnthropic, \
-             patch("exposure_scorer.BATCH_ID_FILE", tmp_path / ".batch_id"), \
-             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}):
-            mock_client = MagicMock()
-            MockAnthropic.return_value = mock_client
-            mock_client.beta.messages.batches.retrieve.return_value = SimpleNamespace(
-                processing_status="ended",
-                request_counts=SimpleNamespace(succeeded=2, errored=0, processing=0),
+             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test"}):
+            mc = MagicMock()
+            MockAnthropic.return_value = mc
+            self._setup_mock(mc)
+            result = score_changed_jobs(jobs_df, scores_path=tmp_path / "scores.csv")
+        assert "score_gesamt" in result.columns
+
+    def test_hash_wird_gespeichert(self, jobs_df, tmp_path):
+        scores_path = tmp_path / "scores.csv"
+        with patch("exposure_scorer.anthropic.Anthropic") as MockAnthropic, \
+             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test"}):
+            mc = MagicMock()
+            MockAnthropic.return_value = mc
+            self._setup_mock(mc)
+            result = score_changed_jobs(jobs_df, scores_path=scores_path)
+        assert "beschreibung_hash" in result.columns
+        assert result["beschreibung_hash"].notna().all()
+
+    def test_keine_aenderung_gibt_bestehende_csv(self, jobs_df, tmp_path):
+        scores_path = tmp_path / "scores.csv"
+        # scores.csv mit aktuellen Hashes erstellen
+        df = jobs_df.copy()
+        df["beschreibung_hash"] = df.apply(
+            lambda r: compute_hash(r["beruf"], r["esco_beschreibung"]), axis=1
+        )
+        df["score_gesamt"] = 5.0
+        df.to_csv(scores_path, index=False)
+        with patch("exposure_scorer.anthropic.Anthropic") as MockAnthropic, \
+             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test"}):
+            mc = MagicMock()
+            MockAnthropic.return_value = mc
+            result = score_changed_jobs(jobs_df, scores_path=scores_path)
+        mc.messages.create.assert_not_called()
+        assert len(result) == 2
+
+    def test_force_leer_scored_alle(self, jobs_df, tmp_path):
+        with patch("exposure_scorer.anthropic.Anthropic") as MockAnthropic, \
+             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test"}):
+            mc = MagicMock()
+            MockAnthropic.return_value = mc
+            self._setup_mock(mc)
+            score_changed_jobs(jobs_df, scores_path=tmp_path / "scores.csv", force=[])
+        assert mc.messages.create.call_count == 2
+
+    def test_force_name_scored_nur_diesen(self, jobs_df, tmp_path):
+        with patch("exposure_scorer.anthropic.Anthropic") as MockAnthropic, \
+             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test"}):
+            mc = MagicMock()
+            MockAnthropic.return_value = mc
+            self._setup_mock(mc)
+            score_changed_jobs(
+                jobs_df, scores_path=tmp_path / "scores.csv",
+                force=["Buchhalter/in"]
             )
-            api_results = [
-                _make_api_result("0", "Buchhalter/in"),
-                _make_api_result("1", "Krankenpfleger/in"),
-            ]
-            mock_client.beta.messages.batches.results.return_value = iter(api_results)
-            score_all_jobs(sample_jobs_df, batch_id="batch_explicit")
-        mock_client.beta.messages.batches.create.assert_not_called()
-        mock_client.beta.messages.batches.retrieve.assert_called_with("batch_explicit")
+        assert mc.messages.create.call_count == 1
+
+    def test_neugesorter_beruf_ersetzt_alten(self, jobs_df, tmp_path):
+        scores_path = tmp_path / "scores.csv"
+        df = jobs_df.copy()
+        df["beschreibung_hash"] = "alter_hash"
+        df["score_gesamt"] = 3.0
+        df.to_csv(scores_path, index=False)
+        with patch("exposure_scorer.anthropic.Anthropic") as MockAnthropic, \
+             patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test"}):
+            mc = MagicMock()
+            MockAnthropic.return_value = mc
+            self._setup_mock(mc, _score_payload(score_gesamt=9.0))
+            result = score_changed_jobs(jobs_df, scores_path=scores_path)
+        assert (result["score_gesamt"] == 9.0).all()
+        assert len(result) == 2


### PR DESCRIPTION
## Summary

- **Batch API entfernt**: `exposure_scorer.py` ruft die Claude API jetzt synchron via `client.messages.create()` auf — kein Polling, kein JSONL-Parsing mehr
- **Hash-basiertes Delta**: SHA-256-Hash von `beruf||beschreibung` ([:12]) wird als `beschreibung_hash` in `scores.csv` gespeichert; nur Berufe mit geänderter ESCO-Beschreibung werden beim nächsten Lauf neu gescort
- **`--force` Flag** für selektives Überschreiben:
  - `--force` → alle 204 Berufe neu scoren
  - `--force "Buchhalter/in"` → nur dieser Beruf (case-insensitive)
  - `--force 2411` → alle ISCO-Präfix-Treffer
  - `--force A B 2411` → mehrere Terme kombinierbar
- **Upsert-Logik**: `score_changed_jobs()` führt neue Scores mit bestehender `scores.csv` zusammen, ohne unveränderte Zeilen zu überschreiben

## Tests

- 34 neue Unit-Tests in `tests/test_exposure_scorer.py`
- Alle Anthropic-API-Calls gemockt — kein echter API-Key nötig
- Coverage Scoring-Modul: **97%** (Gesamtprojekt: 97%)
- 70/70 Tests grün

## Test plan

- [x] `pytest tests/test_exposure_scorer.py -v` → 34/34 grün
- [x] `pytest tests/ --cov=src/scoring` → 97%, alle 70 Tests grün

Closes #22