### PR TITLE
feat: Klick auf Treemap-Feld öffnet Beruf-Detailansicht

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ plotly>=5.18.0
 kaleido==0.2.1        # PNG-Export der Treemap (1.x inkompatibel mit plotly)
 
 # Webapp
-streamlit>=1.32.0
+streamlit>=1.37.0  # on_select für Plotly-Charts (Treemap-Klick → Detail)
 
 # Daten laden
 requests>=2.31.0

--- a/src/app/pages/1_Treemap.py
+++ b/src/app/pages/1_Treemap.py
@@ -114,21 +114,14 @@ event = st.plotly_chart(
 )
 
 # ── Klick auf ein Beruf-Feld → direkt zur Berufssuche ─────────────────────────
-def _points(ev) -> list:
-    if not ev:
-        return []
-    sel = ev.get("selection") if isinstance(ev, dict) else getattr(ev, "selection", None)
-    if not sel:
-        return []
-    if isinstance(sel, dict):
-        return sel.get("points", []) or []
-    return list(getattr(sel, "points", []) or [])
-
-
+points = (event or {}).get("selection", {}).get("points", []) if event else []
 berufe_set = set(filtered["beruf"])
-for _p in _points(event):
-    _label_val = _p.get("label") if isinstance(_p, dict) else getattr(_p, "label", None)
+for _p in points:
+    _label_val = _p.get("label")
     if _label_val in berufe_set:
+        # Auswahl konsumieren, sonst triggert der Widget-State bei Rückkehr
+        # zur Treemap-Seite sofort wieder einen Redirect.
+        st.session_state.pop("treemap_select", None)
         st.query_params["beruf"] = _label_val
         st.switch_page("pages/4_Berufssuche.py")
         break

--- a/src/app/pages/1_Treemap.py
+++ b/src/app/pages/1_Treemap.py
@@ -102,7 +102,36 @@ fig = px.treemap(
     },
 )
 fig.update_layout(height=700, coloraxis_colorbar_title="KI-Score")
-st.plotly_chart(fig, use_container_width=True)
+
+st.caption("💡 Tipp: Klick auf ein Berufsfeld öffnet die Detail-Ansicht.")
+
+event = st.plotly_chart(
+    fig,
+    use_container_width=True,
+    on_select="rerun",
+    selection_mode="points",
+    key="treemap_select",
+)
+
+# ── Klick auf ein Beruf-Feld → direkt zur Berufssuche ─────────────────────────
+def _points(ev) -> list:
+    if not ev:
+        return []
+    sel = ev.get("selection") if isinstance(ev, dict) else getattr(ev, "selection", None)
+    if not sel:
+        return []
+    if isinstance(sel, dict):
+        return sel.get("points", []) or []
+    return list(getattr(sel, "points", []) or [])
+
+
+berufe_set = set(filtered["beruf"])
+for _p in _points(event):
+    _label_val = _p.get("label") if isinstance(_p, dict) else getattr(_p, "label", None)
+    if _label_val in berufe_set:
+        st.query_params["beruf"] = _label_val
+        st.switch_page("pages/4_Berufssuche.py")
+        break
 
 # ── PNG-Export ─────────────────────────────────────────────────────────────────
 try:


### PR DESCRIPTION
## Summary
- Treemap-Felder sind jetzt interaktiv: ein Klick auf ein Berufsfeld setzt `?beruf=…` und navigiert direkt zur Berufssuche-Seite.
- Implementiert via `on_select="rerun"` + `selection_mode="points"` auf `st.plotly_chart`; nur Leaf-Klicks (Beruf) lösen den Sprung aus, Branche-Aggregate behalten die native Plotly-Drilldown-Logik.
- `requirements.txt`: `streamlit>=1.37.0` (on_select-API).

## Test plan
- [ ] `streamlit run src/app/app.py` starten
- [ ] Treemap öffnen, auf ein Berufsfeld klicken → sollte automatisch zur Berufssuche-Seite springen, mit dem passenden Beruf vorausgewählt
- [ ] Klick auf ein Branche-Feld → darf **nicht** navigieren (weiterhin Drilldown / Hover)
- [ ] Deep-Link-URL zeigt `?beruf=<Berufsname>` nach Sprung
- [ ] Tipp-Caption wird oberhalb der Treemap angezeigt

https://claude.ai/code/session_017zpaCzdNWoWGaALKXaCAvX

---
_Generated by [Claude Code](https://claude.ai/code/session_017zpaCzdNWoWGaALKXaCAvX)_