### PR TITLE
docs: Blogpost zur KI-Jobexposition für die Webseite

### DIFF
--- a/blog/ki-jobexposition-schweiz-social.md
+++ b/blog/ki-jobexposition-schweiz-social.md
@@ -1,0 +1,171 @@
+# Begleittexte & Veröffentlichungs-Vorbereitung
+
+Ergänzung zum Blogpost `ki-jobexposition-schweiz.md`.
+
+---
+
+## Social Media Begleittexte
+
+### LinkedIn (~350 Wörter, professioneller Ton)
+
+---
+
+**Welche Schweizer Berufe sind wirklich von KI exponiert — und welche nicht?**
+
+Fast jede Diskussion über KI und Arbeitsplätze in der Schweiz stützt sich auf US-amerikanische
+oder globale Studien: Goldman Sachs, McKinsey, WEF. Was in diesen Zahlen nicht vorkommt:
+das duale Bildungssystem, die Lohnstruktur des Schweizer Finanzplatzes, der Fachkräftemangel
+in der Pflege oder die Rolle von Gesamtarbeitsverträgen beim Tempo der Automatisierung.
+
+Die KOF ETH Zürich hat im Oktober 2025 erstmals empirisch gezeigt, dass KI bereits
+konkrete Spuren auf dem Schweizer Arbeitsmarkt hinterlässt — mit einem 27 % stärkeren
+Anstieg an Stellensuchenden in stark exponierten Berufen seit Ende 2022. Betroffen:
+vor allem Software-Entwickler:innen, Journalist:innen und Fachleute in Marketing und Werbung.
+
+Ich habe ein offenes Tool gebaut, das für **204 Schweizer Berufe** einen nachvollziehbaren
+Expositionsscore liefert — basierend auf BFS-Daten, der europäischen ESCO-Klassifikation
+und einem transparent dokumentierten Scoring-Modell.
+
+Zwei Beispiele aus den Daten:
+
+- **Sachbearbeiter/in Buchhaltung** — Score 8.5, Zeitrahmen 3–5 Jahre. ERP-Systeme und
+  KI-gestützte Belegerfassung automatisieren bereits grosse Teile der Routine.
+- **Diplomierte Pflegefachperson** — Score 1.8, rund 130'000 Beschäftigte. Körperlich-
+  empathische Betreuung lässt sich nicht automatisieren; KI entlastet eher Dokumentation.
+
+Das Tool ist kein Orakel. Ein hoher Score bedeutet nicht, dass ein Beruf verschwindet —
+er bedeutet, dass viele der heutigen Tätigkeiten technisch grundsätzlich für KI-
+Unterstützung geeignet sind. Ob und wann sich das in echten Veränderungen am Arbeitsmarkt
+niederschlägt, hängt von Regulierung, Sozialpartnerschaft und Investitionsentscheiden ab.
+
+Die Daten, der Code und die vollständige Methodik sind öffentlich — damit die Diskussion
+über konkrete Berufe und konkrete Massnahmen geführt werden kann, statt zwischen Panik
+und Beschwichtigung zu pendeln.
+
+👉 Tool: https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz
+📄 Methodik & Code: https://github.com/minigraphx/ki-jobexposition-schweiz
+
+Feedback, Korrekturen und Branchen-Expertise sind ausdrücklich willkommen.
+
+#KI #Arbeitsmarkt #Schweiz #Automatisierung #Berufe #OpenSource
+
+---
+
+### X / Twitter (Thread, 6 Tweets)
+
+---
+
+**Tweet 1 (Hook):**
+Welche Schweizer Berufe sind wirklich von KI exponiert? Fast alle Studien dazu stammen
+aus den USA — ich habe versucht, das mit Schweizer Zahlen zu unterfüttern. 🧵
+
+**Tweet 2 (Problem):**
+Goldman Sachs, McKinsey, WEF — grosse Zahlen, aber nicht auf die Schweiz gerechnet.
+Kein duales Bildungssystem, keine CH-Lohnstruktur, keine Gesamtarbeitsverträge.
+Die KOF ETH hat Oktober 2025 erstmals eigene Empirie geliefert.
+
+**Tweet 3 (Tool):**
+Ergebnis: KI-Jobexposition Schweiz — 204 Berufe, nachvollziehbarer Score 0–10,
+offen dokumentierte Methodik. Gebaut auf BFS SAKE 2024, ESCO und BFS LSE 2022.
+Jeder Score hat eine Begründung.
+
+**Tweet 4 (Beispiele):**
+Stark exponiert: Sachbearbeiter/in Buchhaltung (8.5), Übersetzer/in (7.3)
+Schwach exponiert: Coiffeur/in EFZ (1.6), Dipl. Pflegefachperson (1.8)
+→ 130'000 Pflegefachpersonen: KI entlastet eher, als dass sie verdrängt.
+
+**Tweet 5 (Grenzen):**
+Was das Tool *nicht* ist: kein Orakel, keine Berufsempfehlung. Ein Score ist
+ein Einstieg in ein Gespräch — keine Grundlage für Kündigung oder Berufswahl.
+Regulierung, Sozialpartnerschaft und GAV modelliert es nicht.
+
+**Tweet 6 (CTA):**
+Tool: https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz
+Code & Methodik: https://github.com/minigraphx/ki-jobexposition-schweiz
+Kritik, Korrekturen, Branchen-Expertise willkommen — gerne hier oder via GitHub Issues.
+
+---
+
+### Newsletter (120 Wörter, persönlicher Ton)
+
+---
+
+**Schweizer Berufe und KI — endlich eigene Zahlen**
+
+Fast alle Studien zu KI und Arbeitsplätzen rechnen für die USA. Ich habe versucht,
+das für die Schweiz nachzubauen: 204 Berufe aus der BFS-Arbeitskräfteerhebung,
+bewertet nach fünf Kriterien, mit Schweizer Branchen- und Lohnanpassungen.
+
+Zwei Befunde, die mich überrascht haben: Software-Entwickler:innen sind laut
+KOF-Studie (Oktober 2025) unter den am stärksten betroffenen Berufen — nicht
+die sicherste Wette, wie lange angenommen. Und 130'000 diplomierte Pflegefachpersonen
+haben einen Score von 1.8 — KI entlastet hier, verdrängt nicht.
+
+Das Tool ist offen, die Methodik dokumentiert, Kritik willkommen.
+
+→ https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz
+
+---
+
+## Bild- und Grafik-Vorschläge
+
+Folgende Screenshots / Grafiken sollten vor der Veröffentlichung erstellt werden:
+
+| # | Beschreibung | Wo im Artikel | Hinweis |
+|---|---|---|---|
+| 1 | **Treemap-Screenshot** — alle 204 Berufe sichtbar, Zoom auf einige Extremfälle | Nach «Was das Tool macht» | Im Tool: Treemap-Tab öffnen, Vollbild-Screenshot |
+| 2 | **Radar-Chart** für Sachbearbeiter/in Buchhaltung | Im Abschnitt «Vier Beispiele» | In der Berufssuche des Tools exportieren oder Screenshot |
+| 3 | **Matrix-View** (Exposition × Anpassungsfähigkeit) — 4 Quadranten sichtbar | Alternativ nach Beispielen | Matrix-Tab im Tool |
+| 4 | **Score-Verteilung** (Histogramm 0–10) — zeigt, dass die meisten Berufe im mittleren Bereich liegen | Optional in der Methodik-Sektion | Via `scores.csv` mit Python/Plotly/Matplotlib generieren |
+
+**Vorgeschlagene Alt-Texte:**
+- Bild 1: `Treemap aller 204 Schweizer Berufe nach KI-Expositionsscore — Grösse entspricht Beschäftigtenzahl, Farbe dem Score (rot = hoch, grün = niedrig)`
+- Bild 2: `Radar-Chart Sachbearbeiter/in Buchhaltung: hohe Scores bei digitalem Output und Wiederholbarkeit, niedrig bei physischer Präsenz`
+- Bild 3: `Matrix: KI-Exposition (Y-Achse) gegen Anpassungsfähigkeit (X-Achse) — vier Quadranten`
+
+---
+
+## Veröffentlichungs-Checkliste
+
+Vor der Publikation folgende Punkte prüfen:
+
+### Pflichtprüfungen
+
+- [ ] **HuggingFace Space** erreichbar: https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz
+- [ ] **GitHub Repo** erreichbar: https://github.com/minigraphx/ki-jobexposition-schweiz
+- [ ] **EU AI Act** (EUR-Lex): https://eur-lex.europa.eu/eli/reg/2024/1689/oj
+- [ ] **revDSG** (Fedlex): https://www.fedlex.admin.ch/eli/cc/2022/491/de
+- [ ] **BFS SAKE**: https://www.bfs.admin.ch/bfs/de/home/statistiken/arbeit-erwerb/erhebungen/sake.html
+- [ ] **ESCO**: https://esco.ec.europa.eu/de
+
+### Schweizer Medien-URLs (liefern meist 403 bei direktem Fetch — im Browser prüfen)
+
+- [ ] Blick: https://www.blick.ch/wirtschaft/grosse-studie-zur-ki-revolution-mehr-als-jeder-zweite-schweizer-fuerchtet-sich-vor-job-verlust-id19927518.html
+- [ ] 20 Minuten: https://www.20min.ch/story/duesteres-szenario-ki-koryphaee-warnt-vor-80-prozent-arbeitslosigkeit-103464159
+- [ ] NZZ: https://www.nzz.ch/wirtschaft/kof-studie-ki-veraendert-den-schweizer-arbeitsmarkt-dramatisch-ld.1905520
+
+### Akademische/institutionelle Quellen
+
+- [ ] KOF ETH: https://kof.ethz.ch/news-und-veranstaltungen/kof-news/2025/10/kuenstliche-intelligenz-hinterlaesst-deutliche-spuren-auf-dem-schweizer-arbeitsmarkt.html
+- [ ] Avenir Suisse: https://www.avenir-suisse.ch/publication/zukunftssichere-berufe/
+- [ ] PwC: https://www.pwc.ch/de/presse/AI_Jobs_Barometer_2025.html
+- [ ] WEF: https://reports.weforum.org/docs/WEF_Future_of_Jobs_Report_2025.pdf
+- [ ] IMF: https://www.imf.org/-/media/files/publications/sdn/2024/english/sdnea2024001.pdf
+- [ ] arXiv Eloundou: https://arxiv.org/abs/2303.10130
+- [ ] SSRN Webb: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3482150
+- [ ] KOF «richer»: https://kof.ethz.ch/en/publications/kof-insights/articles/2025/12/i-expect-ai-to-make-us-all-richer.html
+
+### Inhaltliche Endprüfung
+
+- [ ] Score-Werte der 4 Beispielberufe in `data/processed/scores.csv` nochmals verifiziert
+- [ ] Alle Zahlen (27 %, 20'000 Stellen, 130'000 Beschäftigte) mit Quellen abgeglichen
+- [ ] Schreibweise konsistent: «KI» (nicht «AI»), «KI-Exposition», «Expositionsscore»
+- [ ] Kein Plural-s bei Berufsbezeichnungen im Generischen (Tool verwendet offizielle BFS-Schreibweise)
+- [ ] Fussnoten vollständig und nummeriert im Markdown korrekt gerendert (Vorschau im Browser testen)
+
+### Formales
+
+- [ ] YAML Frontmatter: `date` auf Publikationstag anpassen
+- [ ] Tags vollständig und korrekt: `[KI, Arbeitsmarkt, Schweiz, Datenanalyse, Automatisierung]`
+- [ ] Bilder vorhanden (siehe Grafik-Vorschläge oben) und Alt-Texte gesetzt
+- [ ] Artikel-URL (Slug) festgelegt — Vorschlag: `ki-jobexposition-schweiz`

--- a/blog/ki-jobexposition-schweiz-social.md
+++ b/blog/ki-jobexposition-schweiz-social.md
@@ -133,27 +133,27 @@ Vor der Publikation folgende Punkte prüfen:
 
 - [ ] **HuggingFace Space** erreichbar: https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz
 - [ ] **GitHub Repo** erreichbar: https://github.com/minigraphx/ki-jobexposition-schweiz
-- [ ] **EU AI Act** (EUR-Lex): https://eur-lex.europa.eu/eli/reg/2024/1689/oj
-- [ ] **revDSG** (Fedlex): https://www.fedlex.admin.ch/eli/cc/2022/491/de
+- [x] **EU AI Act** (EUR-Lex): https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng *(URL auf `/eng` korrigiert)*
+- [x] **revDSG** (Fedlex): https://www.fedlex.admin.ch/eli/cc/2022/491/de
 - [ ] **BFS SAKE**: https://www.bfs.admin.ch/bfs/de/home/statistiken/arbeit-erwerb/erhebungen/sake.html
 - [ ] **ESCO**: https://esco.ec.europa.eu/de
 
-### Schweizer Medien-URLs (liefern meist 403 bei direktem Fetch — im Browser prüfen)
+### Schweizer Medien-URLs (verifiziert via Websearch)
 
-- [ ] Blick: https://www.blick.ch/wirtschaft/grosse-studie-zur-ki-revolution-mehr-als-jeder-zweite-schweizer-fuerchtet-sich-vor-job-verlust-id19927518.html
-- [ ] 20 Minuten: https://www.20min.ch/story/duesteres-szenario-ki-koryphaee-warnt-vor-80-prozent-arbeitslosigkeit-103464159
-- [ ] NZZ: https://www.nzz.ch/wirtschaft/kof-studie-ki-veraendert-den-schweizer-arbeitsmarkt-dramatisch-ld.1905520
+- [x] Blick: https://www.blick.ch/wirtschaft/grosse-studie-zur-ki-revolution-mehr-als-jeder-zweite-schweizer-fuerchtet-sich-vor-job-verlust-id19927518.html
+- [x] 20 Minuten: https://www.20min.ch/story/duesteres-szenario-ki-koryphaee-warnt-vor-80-prozent-arbeitslosigkeit-103464159
+- [x] NZZ: https://www.nzz.ch/wirtschaft/kof-studie-ki-veraendert-den-schweizer-arbeitsmarkt-dramatisch-ld.1905520 *(Paywall, URL gültig)*
 
-### Akademische/institutionelle Quellen
+### Akademische/institutionelle Quellen (alle verifiziert ✓)
 
-- [ ] KOF ETH: https://kof.ethz.ch/news-und-veranstaltungen/kof-news/2025/10/kuenstliche-intelligenz-hinterlaesst-deutliche-spuren-auf-dem-schweizer-arbeitsmarkt.html
-- [ ] Avenir Suisse: https://www.avenir-suisse.ch/publication/zukunftssichere-berufe/
-- [ ] PwC: https://www.pwc.ch/de/presse/AI_Jobs_Barometer_2025.html
-- [ ] WEF: https://reports.weforum.org/docs/WEF_Future_of_Jobs_Report_2025.pdf
-- [ ] IMF: https://www.imf.org/-/media/files/publications/sdn/2024/english/sdnea2024001.pdf
-- [ ] arXiv Eloundou: https://arxiv.org/abs/2303.10130
-- [ ] SSRN Webb: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3482150
-- [ ] KOF «richer»: https://kof.ethz.ch/en/publications/kof-insights/articles/2025/12/i-expect-ai-to-make-us-all-richer.html
+- [x] KOF ETH: https://kof.ethz.ch/news-und-veranstaltungen/kof-news/2025/10/kuenstliche-intelligenz-hinterlaesst-deutliche-spuren-auf-dem-schweizer-arbeitsmarkt.html
+- [x] Avenir Suisse: https://www.avenir-suisse.ch/publication/zukunftssichere-berufe/
+- [x] PwC: https://www.pwc.ch/de/presse/AI_Jobs_Barometer_2025.html
+- [x] WEF: https://reports.weforum.org/docs/WEF_Future_of_Jobs_Report_2025.pdf
+- [x] IMF: https://www.imf.org/-/media/files/publications/sdn/2024/english/sdnea2024001.pdf
+- [x] arXiv Eloundou: https://arxiv.org/abs/2303.10130
+- [x] SSRN Webb: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3482150
+- [x] KOF «richer»: https://kof.ethz.ch/en/publications/kof-insights/articles/2025/12/i-expect-ai-to-make-us-all-richer.html
 
 ### Inhaltliche Endprüfung
 

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -1,5 +1,5 @@
 ---
-title: "Welche Schweizer Berufe trifft die KI-Welle? Warum wir endlich eigene Zahlen brauchen"
+title: "Welche Schweizer Berufe trifft die KI-Welle? Ein Versuch mit Schweizer Daten"
 date: 2026-04-26
 tags: [KI, Arbeitsmarkt, Schweiz, Datenanalyse, Automatisierung]
 description: >
@@ -10,12 +10,13 @@ description: >
 
 # Welche Schweizer Berufe trifft die KI-Welle?
 
-## Warum wir endlich eigene Zahlen brauchen
+## Ein Versuch mit Schweizer Daten
 
 > **Kurz:** Fast alle bekannten KI-Arbeitsmarkt-Studien sind global oder US-zentriert —
-> der Schweizer Kontext fehlt. Das Tool *KI-Jobexposition Schweiz* gibt für 204 Schweizer
-> Berufe einen nachvollziehbaren Expositionsscore, erklärt die Methodik offen und
-> benennt, was die Daten *nicht* leisten können.
+> der Schweizer Kontext fehlt. *KI-Jobexposition Schweiz* ist keine wissenschaftliche
+> Studie, sondern ein offenes Tool: Für 204 Schweizer Berufe liefert es eine
+> strukturierte Schätzung der KI-Exposition, legt das Vorgehen offen und benennt,
+> was die Daten *nicht* leisten können.
 
 **Inhalt**
 
@@ -145,10 +146,11 @@ kann, statt zwischen Panik und Beschwichtigung zu pendeln.
 ### 1. Niemand spricht über *konkrete* Berufe
 
 Die meisten Diskussionen bleiben abstrakt: «kreative Berufe», «Wissensarbeit»,
-«Routine-Tätigkeiten». Das ist analytisch wertlos für eine 24-jährige Kauffrau, die
-sich fragt, ob sie sich umorientieren soll, oder für einen Berufsberater, der eine
-Lehrstelle empfehlen will. Was diese Menschen brauchen, ist keine Schlagzeile — sie
-brauchen eine Antwort auf die Frage: **«Wie sieht es bei *meinem* Beruf aus?»**
+«Routine-Tätigkeiten». Das hilft einer 24-jährigen Kauffrau, die sich fragt, ob sie
+sich umorientieren soll, nicht weiter — und auch nicht einem 45-jährigen
+Sachbearbeiter, der überlegt, in welche Weiterbildung er Zeit und Geld investiert.
+Was diese Menschen brauchen, ist keine Schlagzeile — sondern ein erster konkreter
+Anhaltspunkt zur Frage: **«Wie sieht es bei *meinem* Beruf aus?»**
 
 ### 2. Die Schweizer Wirtschaft folgt nicht dem US-Drehbuch
 
@@ -197,25 +199,29 @@ anders oder gar nicht von KI verändert werden, weil rechtliche und sozialpartne
 Leitplanken im Weg stehen. Das Tool kann diese Faktoren nicht modellieren — aber wer
 seine Ergebnisse interpretiert, sollte sie mitdenken.
 
-### 4. Detaildaten und Reproduzierbarkeit fehlen häufig
+### 4. Detaildaten pro Beruf fehlen oft
 
 McKinsey, OECD und das ILO-Arbeitsmarktteam dokumentieren ihre Methodik in der Regel
 in technischen Anhängen oder Working Papers — das ist anzuerkennen.[^mckinsey] [^oecd]
-[^ilo] Was in der Praxis aber häufig fehlt, ist die Ebene darunter: die **Bewertung
-pro einzelner Berufsgruppe** in maschinenlesbarer Form, die genauen Coding-Entscheide
-und reproduzierbarer Code. Damit bleibt es schwierig, einen einzelnen Beruf
-nachzurechnen oder die Annahmen für den eigenen Kontext zu hinterfragen — gerade
-diese Ebene ist es aber, die für Berufsberatung, Branchenverbände und Betroffene
-relevant ist.
+[^ilo] Was in der Praxis häufig fehlt, ist die Ebene darunter: die **Bewertung pro
+einzelner Berufsgruppe** in maschinenlesbarer Form, dazu die Coding-Entscheide und
+der Code. Damit bleibt es schwierig, einen einzelnen Beruf nachzurechnen oder die
+Annahmen für den eigenen Kontext zu hinterfragen — gerade das ist aber die Ebene,
+auf der eine konkrete Diskussion über einzelne Berufe stattfinden müsste. Das Tool
+versucht hier, mehr Transparenz herzustellen — ohne damit den Anspruch zu erheben,
+selbst eine peer-reviewte oder im wissenschaftlichen Sinne reproduzierbare
+Untersuchung zu sein.
 
 ---
 
 ## Was das Tool macht
 
-Die Plattform berechnet pro Beruf einen **Expositionsscore von 0 bis 10** auf Basis
-einer öffentlich dokumentierten Methodik. Der Score misst, wie stark sich die
+Die Plattform berechnet pro Beruf einen **Expositionsscore von 0 bis 10** nach einer
+öffentlich dokumentierten Vorgehensweise. Der Score misst, wie stark sich die
 *Tätigkeiten* eines Berufs grundsätzlich für generative KI eignen — nicht, ob und
-wann der Beruf tatsächlich verändert wird.
+wann ein Beruf tatsächlich verändert wird. Es handelt sich ausdrücklich **nicht um
+eine wissenschaftliche Studie**, sondern um eine strukturierte Schätzung mit offenen
+Annahmen.
 
 1. **Datengrundlage:** 204 Berufe aus der Schweizerischen Arbeitskräfteerhebung
    ([BFS SAKE 2024][bfs-sake]), angereichert mit offiziellen Berufsbeschreibungen
@@ -297,26 +303,27 @@ Personalentscheidungen.
 
 - **Berufstätige**, die für sich selbst eine Diskussionsgrundlage suchen, wie sich
   ihr Tätigkeitsfeld verändern könnte.
-- **Berufsberater:innen und Lehrpersonen**, die Jugendlichen ergänzendes Material zur
-  Berufswahl an die Hand geben wollen — neben den etablierten Quellen.
+- **Lehrpersonen**, die KI und Arbeitsmarkt im Unterricht thematisieren wollen —
+  als Diskussionsanstoss, nicht als Berufswahl-Instrument.
 - **HR und Strategie**, die ein zusätzliches Datenpuzzlestück für Personalplanung
   und Weiterbildung suchen.
 - **Politik und Verbände**, die für ihre Diskussionen über Strukturwandel und
   Weiterbildung neben qualitativen Einschätzungen auch quantitative Anhaltspunkte
   brauchen.
 - **Journalist:innen und Forschende**, die für ihre Beiträge nachvollziehbare
-  Schweizer Zahlen suchen — inklusive der Möglichkeit, der Methodik zu widersprechen.
+  Schweizer Zahlen suchen — inklusive der Möglichkeit, der Vorgehensweise zu
+  widersprechen.
 
 ---
 
 ## Ein Anfang, kein Endpunkt
 
 KI-Jobexposition Schweiz ist ein **offenes Projekt** und ausdrücklich ein Versuch,
-keine fertige Antwort. Die Daten und die Methodik sind unter MIT-Lizenz frei
+keine fertige Antwort. Die Daten und das Vorgehen sind unter MIT-Lizenz frei
 verfügbar, der Code ist öffentlich, jeder Score wird mit Begründung publiziert.
-Wo die Methodik Schwächen hat, sollen sie sichtbar sein — Kritik, Korrekturvorschläge
-und Branchen-Expertise sind ausdrücklich willkommen, über GitHub-Issues oder direkt
-per Mail.
+Wo die Vorgehensweise Schwächen hat, sollen sie sichtbar sein — Kritik,
+Korrekturvorschläge und Branchen-Expertise sind ausdrücklich willkommen, über
+GitHub-Issues oder direkt per Mail.
 
 Wir werden uns in den nächsten Jahren intensiv mit der Frage beschäftigen müssen, was
 generative KI mit unserem Arbeitsmarkt macht. Diese Diskussion verdient eine bessere
@@ -325,7 +332,7 @@ diese Daten *nicht* leisten können.
 
 **👉 [Tool öffnen](https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz)**
 &nbsp;·&nbsp;
-**[Code & Methodik auf GitHub](https://github.com/minigraphx/ki-jobexposition-schweiz)**
+**[Code & Dokumentation auf GitHub](https://github.com/minigraphx/ki-jobexposition-schweiz)**
 
 ---
 
@@ -428,26 +435,6 @@ diese Daten *nicht* leisten können.
 [^seco-sozialpartnerschaft]: SECO — Staatssekretariat für Wirtschaft:
     *Sozialpartnerschaft in der Schweiz.* <https://www.seco.admin.ch>
 
-### Schweizer Datenquellen
-
-[bfs-sake]: https://www.bfs.admin.ch/bfs/de/home/statistiken/arbeit-erwerb/erhebungen/sake.html
-    "Schweizerische Arbeitskräfteerhebung (SAKE), Bundesamt für Statistik"
-[bfs-lse]: https://www.bfs.admin.ch/bfs/de/home/statistiken/arbeit-erwerb/loehne-erwerbseinkommen-arbeitskosten/lohnniveau-schweiz/lohnstrukturerhebung.html
-    "Lohnstrukturerhebung (LSE) 2022, Bundesamt für Statistik"
-[esco]: https://esco.ec.europa.eu/de
-    "European Skills, Competences, Qualifications and Occupations, Europäische Kommission"
-
-### Weitere Verweise im Text
-
-[eu-ai-act]: https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng
-    "Verordnung (EU) 2024/1689 – AI Act"
-[revdsg]: https://www.fedlex.admin.ch/eli/cc/2022/491/de
-    "Bundesgesetz über den Datenschutz (revDSG), in Kraft seit 1. September 2023"
-[finma]: https://www.finma.ch
-    "Eidgenössische Finanzmarktaufsicht FINMA"
-[swissmedic]: https://www.swissmedic.ch
-    "Swissmedic – Schweizerisches Heilmittelinstitut"
-
 ### Hinweis zu Interpretationen
 
 Einige Aussagen zu Schweizer Spezifika — etwa zur Abfederungswirkung des
@@ -456,3 +443,18 @@ sind plausible Einordnungen der allgemein verfügbaren Datenlage (BFS, Obsan,
 SECO), aber nicht Ergebnis einer eigenen empirischen Untersuchung. Belegte
 Befunde aus der KOF-Studie 2025 und dem PwC AI Jobs Barometer sind mit
 Footnotes gekennzeichnet.
+
+[bfs-sake]: https://www.bfs.admin.ch/bfs/de/home/statistiken/arbeit-erwerb/erhebungen/sake.html
+    "Schweizerische Arbeitskräfteerhebung (SAKE), Bundesamt für Statistik"
+[bfs-lse]: https://www.bfs.admin.ch/bfs/de/home/statistiken/arbeit-erwerb/loehne-erwerbseinkommen-arbeitskosten/lohnniveau-schweiz/lohnstrukturerhebung.html
+    "Lohnstrukturerhebung (LSE) 2022, Bundesamt für Statistik"
+[esco]: https://esco.ec.europa.eu/de
+    "European Skills, Competences, Qualifications and Occupations, Europäische Kommission"
+[eu-ai-act]: https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng
+    "Verordnung (EU) 2024/1689 – AI Act"
+[revdsg]: https://www.fedlex.admin.ch/eli/cc/2022/491/de
+    "Bundesgesetz über den Datenschutz (revDSG), in Kraft seit 1. September 2023"
+[finma]: https://www.finma.ch
+    "Eidgenössische Finanzmarktaufsicht FINMA"
+[swissmedic]: https://www.swissmedic.ch
+    "Swissmedic – Schweizerisches Heilmittelinstitut"

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -24,8 +24,12 @@ Medien ankommen:
   Sprachmodelle berührt sein könnten — also kein «80 % der Berufe gehen weg».[^gptsaregpts]
 - McKinsey schätzt, dass bis 2030 **rund 30 % der heute geleisteten Arbeitsstunden
   in den USA automatisierbar sein könnten** — wiederum mit grosser Spannweite.[^mckinsey]
+- Der **WEF Future of Jobs Report 2025** (Januar 2025) erwartet bis 2030 weltweit
+  **11 Millionen neue und 9 Millionen ersetzte Stellen** durch KI und Datenverarbeitung,
+  bei einem **Nettoplus von rund 78 Millionen Jobs** — und einer Verschiebung von
+  **39 % der heutigen Schlüsselqualifikationen**.[^wef]
 
-Was diesen Studien gemeinsam ist: Sie wurden für den **US-Arbeitsmarkt** gerechnet.
+Was diesen Studien gemeinsam ist: Sie sind **global oder US-zentriert** gerechnet.
 
 Wer in der Schweiz arbeitet, lebt in einer anderen Wirtschaft. Andere Branchenstruktur.
 Andere Lohnniveaus. Ein duales Bildungssystem mit EFZ und Höherer Berufsbildung, das in
@@ -38,6 +42,41 @@ an — ein offenes Tool, das für **204 Schweizer Berufe** einen nachvollziehbar
 Anhaltspunkt liefert, wie stark einzelne Tätigkeiten durch generative KI exponiert
 sein *könnten*. Es ist ausdrücklich keine Prognose darüber, welche Jobs verschwinden
 werden, sondern eine Diskussionsgrundlage.
+
+---
+
+## Und was sagen Schweizer Studien?
+
+Die Diskussion ist 2025 nicht mehr abstrakt — auch in der Schweiz liegen erste
+empirische Befunde vor:
+
+- Die **KOF Konjunkturforschungsstelle der ETH Zürich** hat im Oktober 2025
+  erstmals empirisch gezeigt, dass KI bereits konkrete Spuren auf dem Schweizer
+  Arbeitsmarkt hinterlässt: In stark KI-exponierten Berufen ist die Zahl der bei
+  Schweizer Arbeitsämtern registrierten Stellensuchenden seit November 2022 (also
+  seit dem Aufkommen von ChatGPT) im Schnitt **um 27 % stärker** gestiegen als in
+  wenig exponierten Berufen. Auch die Stellenausschreibungen sind in den
+  exponierten Berufen deutlicher zurückgegangen. Besonders sichtbar: Software-
+  Entwickler:innen, Systemanalystinnen, Programmiererinnen, Journalist:innen
+  sowie Fachleute in Werbung und Marketing.[^kof]
+- **Avenir Suisse** kommt in «Zukunftssichere Berufe?» (2024) zum Schluss, dass
+  Führungskräfte und Berufe mit unstrukturierten Aufgaben tendenziell von KI
+  *unterstützt* werden, während Routine-Bürotätigkeiten unter Druck geraten —
+  und plädiert für gezielte Weiterbildung und höhere berufliche Mobilität.[^avenir]
+- Der **PwC AI Jobs Barometer 2025** zählt rund **20'000 Schweizer
+  Stellenausschreibungen mit explizitem KI-Bezug** — eine Verzehnfachung gegenüber
+  2018, was allerdings noch immer nur **1.4 % des Gesamtmarktes** entspricht. Die
+  Nachfrage steigt, ist aber gemessen am Stellenmarkt noch klein.[^pwc]
+
+International ergänzt die **IMF Staff Discussion Note** (Cazzaniga et al., Januar
+2024) das Bild: **Fortgeschrittene Volkswirtschaften** wie die Schweiz sind
+tendenziell stärker exponiert als Schwellenländer, weil ihr Arbeitsmarkt
+kognitiv-intensiver ist; gleichzeitig sind sie eher in der Lage, die produktiven
+Vorteile zu nutzen.[^imf]
+
+Was diese Studien zeigen: Die Frage ist nicht mehr *ob*, sondern *wo* sich KI
+auf den Arbeitsmarkt auswirkt — und auf welche Berufe konkret. Genau dort setzt
+das Tool an.
 
 ---
 
@@ -57,9 +96,11 @@ Ein paar Beispiele, an denen sich die strukturellen Unterschiede zeigen:
 
 - Der Schweizer **Finanzsektor** ist überdurchschnittlich gross und stark digitalisiert —
   was die KI-Exposition tendenziell erhöhen dürfte.
-- Bei **ICT-Berufen** ist die häufige These «am stärksten betroffen» mindestens
-  diskussionswürdig: Vieles deutet darauf hin, dass sie eher komplementär zur KI
-  arbeiten als von ihr ersetzt zu werden — gesichert ist das nicht.
+- Bei **ICT-Berufen** ist die Lage nicht eindeutig: Lange galt die Annahme, sie
+  seien primär komplementär zur KI — die erste Schweizer Empirie (KOF 2025)
+  relativiert das deutlich. Programmierer:innen und Software-Entwickler:innen
+  gehören zu den Gruppen mit dem stärksten Anstieg an Stellensuchenden seit
+  Ende 2022.[^kof]
 - Im **Gesundheitswesen** und in der **Pflege** dominiert in der Schweiz der demografische
   Druck. Personalmangel und Knappheit sprechen dafür, dass Automatisierung dort eher
   entlastet als verdrängt — die konkrete Wirkung bleibt offen.
@@ -229,6 +270,31 @@ diese Daten *nicht* leisten können.
 [^ilo]: International Labour Organization (2023): *Generative AI and Jobs: A
     global analysis of potential effects on job quantity and quality.*
     ILO Working Paper 96. <https://www.ilo.org/publications>
+
+[^wef]: World Economic Forum (2025): *The Future of Jobs Report 2025.*
+    Insight Report, Januar 2025.
+    <https://reports.weforum.org/docs/WEF_Future_of_Jobs_Report_2025.pdf>
+
+[^imf]: Cazzaniga, M., Jaumotte, F., Li, L., Melina, G., Panton, A. J.,
+    Pizzinelli, C., Rockall, E., Tavares, M. M. (2024): *Gen-AI: Artificial
+    Intelligence and the Future of Work.* IMF Staff Discussion Note SDN/2024/001,
+    Januar 2024.
+    <https://www.imf.org/-/media/files/publications/sdn/2024/english/sdnea2024001.pdf>
+
+### Schweiz-spezifische Studien
+
+[^kof]: Klaeui, J., Siegenthaler, M. (2025): *KI und der Schweizer Arbeitsmarkt:
+    Erste Evidenz zu Auswirkungen auf Arbeitslosigkeit und Stellenausschreibungen.*
+    KOF Konjunkturforschungsstelle, ETH Zürich, Oktober 2025.
+    <https://kof.ethz.ch/news-und-veranstaltungen/kof-news/2025/10/kuenstliche-intelligenz-hinterlaesst-deutliche-spuren-auf-dem-schweizer-arbeitsmarkt.html>
+
+[^avenir]: Avenir Suisse (2024): *Zukunftssichere Berufe? Wie künstliche Intelligenz
+    den Schweizer Arbeitsmarkt verändert.*
+    <https://www.avenir-suisse.ch/publication/zukunftssichere-berufe/>
+
+[^pwc]: PwC Schweiz (2025): *AI Jobs Barometer 2025.* Pressemitteilung und
+    Studienauszug.
+    <https://www.pwc.ch/de/presse/AI_Jobs_Barometer_2025.html>
 
 [^webb]: Webb, M. (2020): *The Impact of Artificial Intelligence on the Labor
     Market.* Stanford Working Paper, SSRN.

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -1,0 +1,137 @@
+---
+title: "Welche Schweizer Berufe trifft die KI-Welle? Warum wir endlich eigene Zahlen brauchen"
+date: 2026-04-26
+tags: [KI, Arbeitsmarkt, Schweiz, Datenanalyse, Automatisierung]
+description: >
+  Generative KI verändert die Arbeitswelt schneller, als die Statistik nachkommt — und fast
+  alle bekannten Studien beziehen sich auf die USA. Höchste Zeit für eine datengetriebene
+  Analyse, die den Schweizer Arbeitsmarkt ernst nimmt.
+---
+
+# Welche Schweizer Berufe trifft die KI-Welle?
+
+## Warum wir endlich eigene Zahlen brauchen
+
+Seit dem Aufstieg generativer KI füllt sich die Debatte über die Zukunft der Arbeit
+mit grossen Zahlen und noch grösseren Schlagzeilen: «300 Millionen Jobs gefährdet»,
+«80 % der Berufe betroffen», «das Ende der Bürotätigkeit». Die Studien dahinter sind
+oft seriös — aber sie haben ein gemeinsames Problem: Sie wurden für den **US-Arbeitsmarkt**
+geschrieben.
+
+Wer in der Schweiz arbeitet, lebt in einer anderen Wirtschaft. Andere Branchenstruktur.
+Andere Lohnniveaus. Ein duales Bildungssystem mit EFZ und Höherer Berufsbildung, das in
+keinem amerikanischen Datensatz auftaucht. Und trotzdem werden die US-Zahlen unverändert
+in Schweizer Medien zitiert, als wäre der Coiffeur in Bern dieselbe statistische Einheit
+wie ein *hairdresser* in Houston.
+
+Genau hier setzt **[KI-Jobexposition Schweiz](https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz)**
+an — ein offenes Tool, das für **204 Schweizer Berufe** transparent zeigt, wie stark sie
+durch generative KI exponiert sind.
+
+---
+
+## Die Problematik in drei Punkten
+
+### 1. Niemand spricht über *konkrete* Berufe
+
+Die meisten Diskussionen bleiben abstrakt: «kreative Berufe», «Wissensarbeit»,
+«Routine-Tätigkeiten». Das ist analytisch wertlos für eine 24-jährige Kauffrau, die
+sich fragt, ob sie sich umorientieren soll, oder für einen Berufsberater, der eine
+Lehrstelle empfehlen will. Was diese Menschen brauchen, ist keine Schlagzeile — sie
+brauchen eine Antwort auf die Frage: **«Wie sieht es bei *meinem* Beruf aus?»**
+
+### 2. Die Schweizer Wirtschaft folgt nicht dem US-Drehbuch
+
+Ein paar Beispiele, die die nationalen Unterschiede deutlich machen:
+
+- Der Schweizer **Finanzsektor** ist überdurchschnittlich gross und überdurchschnittlich
+  digital — was die KI-Exposition tendenziell erhöht.
+- **ICT-Berufe** sind in der Schweiz nicht «am stärksten betroffen», wie oft behauptet —
+  sie sind selbst die Treiber der Automatisierung und werden eher komplementär als
+  ersetzend.
+- Im **Gesundheitswesen** und in der **Pflege** schlägt der demografische Druck stärker
+  als die Automatisierung — hier herrscht Personalmangel, nicht Überfluss.
+- Das **EFZ-System** mit seiner engen Verzahnung von Theorie und Praxis schützt viele
+  Berufe, die in den USA als rein «kognitiv» klassifiziert würden.
+
+Diese Differenzen sind nicht kosmetisch. Sie verändern das Ranking ganzer Berufsgruppen.
+
+### 3. Vorhandene Studien sind nicht öffentlich nachvollziehbar
+
+Wer auf eine McKinsey- oder OECD-Studie verweist, bekommt am Ende eine Grafik. Was er
+nicht bekommt: die Daten, die Methodik im Detail, eine Möglichkeit, die Annahmen zu
+hinterfragen. Genau diese Nachvollziehbarkeit ist aber die Voraussetzung dafür, dass
+Politik, Bildungseinrichtungen und Betroffene fundierte Entscheidungen treffen können.
+
+---
+
+## Was das Tool macht
+
+Die Plattform berechnet pro Beruf einen **Expositionsscore von 0 bis 10** — und zwar
+auf Basis einer öffentlich dokumentierten Methodik:
+
+1. **Datengrundlage:** 204 Berufe aus der Schweizerischen Arbeitskräfteerhebung
+   (BFS SAKE 2024), angereichert mit offiziellen Berufsbeschreibungen aus der
+   europäischen ESCO-Klassifikation und Schweizer Lohndaten (BFS LSE 2022).
+
+2. **Bewertung durch ein KI-Sprachmodell** (Claude Sonnet) entlang von fünf Kriterien:
+   digitaler Output, Wiederholbarkeit, physische Präsenz, Kreativität und soziale
+   Interaktion. Die Methodik orientiert sich an Andrej Karpathys und Michael Webbs
+   Arbeit zur Automatisierungsexposition.
+
+3. **Schweiz-spezifische Anpassungen:** Auf den Rohscore werden Korrekturen für
+   Branche und Lohnniveau angewendet — basierend auf der Struktur der Schweizer
+   Wirtschaft, nicht auf US-Mittelwerten.
+
+4. **Visualisierung:** Eine Treemap zeigt alle 204 Berufe nach Beschäftigtenzahl und
+   Risiko. Eine Matrix-Ansicht stellt Exposition gegen Anpassungsfähigkeit. Eine
+   Berufssuche liefert für jeden einzelnen Beruf das volle Profil mit Begründung.
+
+Wer will, kann jeden Score nachvollziehen, jeden Datensatz herunterladen und jeden
+Schritt der Pipeline auf [GitHub](https://github.com/minigraphx/ki-jobexposition-schweiz)
+einsehen.
+
+---
+
+## Was das Tool *nicht* ist
+
+Damit kein falscher Eindruck entsteht: Diese Plattform ist **kein Orakel**. Ein hoher
+Score bedeutet nicht, dass ein Beruf in fünf Jahren verschwindet — er bedeutet, dass
+ein grosser Anteil der heutigen Tätigkeiten technisch automatisierbar ist. Ob diese
+Automatisierung tatsächlich passiert, hängt von Regulierung, Tarifpartnern, Kundennachfrage,
+Arbeitsmarktdynamik und vielen weiteren Faktoren ab.
+
+Auch das KI-Modell, das hinter den Scores steht, hat blinde Flecken. Es kennt keine
+Werkstatt von innen, hat noch nie eine Patientin betreut und versteht den Schweizer
+Föderalismus nur über Textquellen. Deshalb sind alle Ergebnisse mit konkreten Begründungen
+hinterlegt — damit Leserinnen und Leser selbst beurteilen können, ob die Argumentation
+trägt.
+
+---
+
+## Für wen das Tool gemacht ist
+
+- **Berufstätige**, die wissen wollen, wie sich ihr Tätigkeitsfeld verändern könnte.
+- **Berufsberater:innen und Lehrpersonen**, die Jugendliche bei der Berufswahl begleiten.
+- **HR und Strategie**, die Personalplanung jenseits von Schlagzeilen betreiben wollen.
+- **Politik und Verbände**, die Weiterbildung, Strukturwandel und Sozialversicherungen
+  evidenzbasiert gestalten müssen.
+- **Journalist:innen und Forschende**, die für ihre Beiträge nachvollziehbare
+  Schweizer Zahlen brauchen.
+
+---
+
+## Ein Anfang, kein Endpunkt
+
+KI-Jobexposition Schweiz ist ein **offenes Projekt**. Die Daten und die Methodik
+sind unter MIT-Lizenz frei verfügbar, der Code ist öffentlich, jeder Score wird mit
+Begründung publiziert. Kritik, Korrekturvorschläge und Branchen-Expertise sind
+ausdrücklich willkommen — über GitHub-Issues oder direkt per Mail.
+
+Wir werden uns in den nächsten Jahren intensiv mit der Frage beschäftigen müssen, was
+generative KI mit unserem Arbeitsmarkt macht. Diese Diskussion verdient bessere
+Datenbasis als US-Schlagzeilen.
+
+**👉 [Tool öffnen](https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz)**
+&nbsp;·&nbsp;
+**[Code & Methodik auf GitHub](https://github.com/minigraphx/ki-jobexposition-schweiz)**

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -12,6 +12,24 @@ description: >
 
 ## Warum wir endlich eigene Zahlen brauchen
 
+> **Kurz:** Fast alle bekannten KI-Arbeitsmarkt-Studien sind global oder US-zentriert —
+> der Schweizer Kontext fehlt. Das Tool *KI-Jobexposition Schweiz* gibt für 204 Schweizer
+> Berufe einen nachvollziehbaren Expositionsscore, erklärt die Methodik offen und
+> benennt, was die Daten *nicht* leisten können.
+
+**Inhalt**
+
+1. [Und was sagen Schweizer Studien?](#und-was-sagen-schweizer-studien)
+2. [Drei Schlagzeilen im Reality-Check](#drei-schlagzeilen-im-reality-check)
+3. [Die Problematik in vier Punkten](#die-problematik-in-vier-punkten)
+4. [Was das Tool macht](#was-das-tool-macht)
+5. [Vier Beispiele aus den Daten](#vier-beispiele-aus-den-daten)
+6. [Was das Tool nicht ist](#was-das-tool-nicht-ist)
+7. [Für wen das Tool ein Ausgangspunkt sein kann](#für-wen-das-tool-ein-ausgangspunkt-sein-kann)
+8. [Ein Anfang, kein Endpunkt](#ein-anfang-kein-endpunkt)
+
+---
+
 Seit dem Aufstieg generativer KI füllt sich die Debatte über die Zukunft der Arbeit
 mit grossen Zahlen und noch grösseren Schlagzeilen. Bei näherer Betrachtung sind
 diese Zahlen meist präziser — und vorsichtiger — formuliert, als sie in den
@@ -27,9 +45,8 @@ Medien ankommen:
   über ganze Berufe.[^gptsaregpts]
 - McKinsey schätzt, dass bis 2030 **rund 30 % der heute geleisteten Arbeitsstunden
   in den USA automatisierbar sein könnten** — wiederum mit grosser Spannweite.[^mckinsey]
-- Der **WEF Future of Jobs Report 2025** (Januar 2025) erwartet bis 2030 weltweit
-  **11 Millionen neue und 9 Millionen ersetzte Stellen** durch KI und Datenverarbeitung,
-  bei einem **Nettoplus von rund 78 Millionen Jobs** — und einer Verschiebung von
+- Der **WEF Future of Jobs Report 2025** (Januar 2025) erwartet bis 2030 ein
+  **Nettoplus von rund 78 Millionen Jobs** — bei gleichzeitiger Verschiebung von
   **39 % der heutigen Schlüsselqualifikationen**.[^wef]
 
 Was diesen Studien gemeinsam ist: Sie sind **global oder US-zentriert** gerechnet.
@@ -267,15 +284,12 @@ Veränderungen am Arbeitsmarkt werden, hängt von Regulierung, Recht, Tarifpartn
 Kundennachfrage, Investitionsentscheiden und vielen weiteren Faktoren ab, die das
 Modell nicht kennt.
 
-Auch das KI-Modell, das hinter den Scores steht, hat blinde Flecken. Es kennt keine
-Werkstatt von innen, hat noch nie eine Patientin betreut und versteht den Schweizer
-Föderalismus nur über Textquellen. Die Scores sind deshalb mit Begründungen hinterlegt
-— so können Leserinnen und Leser selbst prüfen, ob die Argumentation für ihren Beruf
-trägt, und im Zweifel der eigenen Erfahrung mehr Gewicht geben als dem Wert.
-
-Niemand sollte aufgrund eines Scores eine Berufswahl, eine Kündigung oder eine
-Personalentscheidung treffen. Die Daten sind ein Einstieg in ein Gespräch, kein
-Ersatz dafür.
+Auch das KI-Modell hinter den Scores hat blinde Flecken: Es kennt keine Werkstatt
+von innen und versteht den Schweizer Föderalismus nur aus Textquellen. Die Scores
+sind deshalb mit Begründungen hinterlegt — damit Leserinnen und Leser selbst prüfen
+können, ob die Argumentation für ihren Beruf trägt. Ein Score ist ein Einstieg in ein
+Gespräch, kein Ersatz für Erfahrung und keine Grundlage für Berufswahl oder
+Personalentscheidungen.
 
 ---
 

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -80,6 +80,46 @@ das Tool an.
 
 ---
 
+## Drei Schlagzeilen im Reality-Check
+
+Wie kommen diese Befunde in den Schweizer Medien an? Drei Beispiele aus 2025 —
+und was wirklich dahintersteht.
+
+### «Mehr als jeder zweite Schweizer fürchtet sich vor Job-Verlust wegen KI»
+*(Blick, Juli 2025)[^blick]*
+
+Die Schlagzeile beruht auf einer Umfrage. Was sie misst, ist die **Sorge**, nicht
+die tatsächliche Bedrohung. Subjektives Gefühl und faktische KI-Exposition können
+weit auseinanderliegen: Beschäftigte mit eher robusten Berufen können sich grosse
+Sorgen machen, während andere mit hochexponierten Tätigkeiten ihre Lage
+unterschätzen. Die Zahl beschreibt ein Stimmungsbild, keinen Arbeitsmarkt.
+
+### «KI-Koryphäe warnt vor 80 Prozent Arbeitslosigkeit»
+*(20 Minuten, über Stuart Russell)[^russell]*
+
+Russell ist ein renommierter KI-Forscher in Berkeley — aber Arbeitsmarkt­ökonom
+ist er nicht. Solche Maximalprognosen finden sich auf beiden Seiten der Debatte,
+von «KI macht uns alle reicher»[^kof-rich] bis «80 Prozent sind weg». Die seriöse
+empirische Forschung (KOF, IMF, WEF) bewegt sich in einem deutlich engeren
+Korridor. Eine Einzelstimme — egal wie prominent — ersetzt keine Studienlage.
+
+### «KOF-Studie: KI verändert den Schweizer Arbeitsmarkt dramatisch»
+*(NZZ, Oktober 2025)[^nzz-kof]*
+
+Inhaltlich nicht falsch — aber durch das Wort «dramatisch» zugespitzter, als die
+Studie selbst formuliert. Die KOF-Daten zeigen einen *relativen* Anstieg um 27 %
+bei den Stellensuchenden in stark exponierten Berufen, gemessen an wenig
+exponierten Berufen. Das ist eine messbare Verschiebung in einem Teilsegment des
+Arbeitsmarkts, kein Massenphänomen — und die Studienautoren selbst formulieren
+deutlich vorsichtiger.
+
+Solche Verkürzungen sind nicht überraschend, Schlagzeilen müssen funktionieren.
+Aber sie zeigen, warum es eine Datenebene **unter** den Schlagzeilen braucht:
+damit die Diskussion über konkrete Berufe und konkrete Massnahmen geführt werden
+kann, statt zwischen Panik und Beschwichtigung zu pendeln.
+
+---
+
 ## Die Problematik in vier Punkten
 
 ### 1. Niemand spricht über *konkrete* Berufe
@@ -326,6 +366,24 @@ diese Daten *nicht* leisten können.
 [^pwc]: PwC Schweiz (2025): *AI Jobs Barometer 2025.* Pressemitteilung und
     Studienauszug.
     <https://www.pwc.ch/de/presse/AI_Jobs_Barometer_2025.html>
+
+### Schlagzeilen
+
+[^blick]: Blick (2025): *Grosse Studie zur KI-Revolution: Mehr als jeder zweite
+    Schweizer fürchtet sich vor Job-Verlust.*
+    <https://www.blick.ch/wirtschaft/grosse-studie-zur-ki-revolution-mehr-als-jeder-zweite-schweizer-fuerchtet-sich-vor-job-verlust-id19927518.html>
+
+[^russell]: 20 Minuten (2025): *Düsteres Szenario — KI-Koryphäe warnt vor
+    80 Prozent Arbeitslosigkeit.*
+    <https://www.20min.ch/story/duesteres-szenario-ki-koryphaee-warnt-vor-80-prozent-arbeitslosigkeit-103464159>
+
+[^nzz-kof]: NZZ (2025): *KOF-Studie: KI verändert den Schweizer Arbeitsmarkt
+    dramatisch.*
+    <https://www.nzz.ch/wirtschaft/kof-studie-ki-veraendert-den-schweizer-arbeitsmarkt-dramatisch-ld.1905520>
+
+[^kof-rich]: Vgl. demgegenüber den Beitrag *«I expect AI to make us all richer»*
+    der KOF (Dezember 2025).
+    <https://kof.ethz.ch/en/publications/kof-insights/articles/2025/12/i-expect-ai-to-make-us-all-richer.html>
 
 [^webb]: Webb, M. (2020): *The Impact of Artificial Intelligence on the Labor
     Market.* Stanford Working Paper, SSRN.

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -17,11 +17,14 @@ mit grossen Zahlen und noch grösseren Schlagzeilen. Bei näherer Betrachtung si
 diese Zahlen meist präziser — und vorsichtiger — formuliert, als sie in den
 Medien ankommen:
 
-- Goldman Sachs schreibt von «bis zu **300 Millionen weltweit *exponierten*
-  Vollzeitstellen**» — nicht von 300 Millionen wegfallenden Jobs.[^goldman]
-- Eloundou et al. (OpenAI / University of Pennsylvania) zeigen, dass rund
+- Eine Goldman-Sachs-Studie (2023) schätzt, dass weltweit bis zu **300 Millionen
+  Vollzeitstellen** durch KI *exponiert* sind — also in unterschiedlichem Mass
+  von Automatisierung berührt. Exposition ist dabei nicht dasselbe wie Wegfall;
+  in vielen Schlagzeilen ist diese Unterscheidung verloren gegangen.[^goldman]
+- Eloundou et al. (OpenAI / University of Pennsylvania, 2023) finden, dass rund
   **80 % der US-Beschäftigten in mindestens 10 % ihrer Aufgaben** durch grosse
-  Sprachmodelle berührt sein könnten — also kein «80 % der Berufe gehen weg».[^gptsaregpts]
+  Sprachmodelle betroffen sein könnten — eine Aussage über *Aufgaben*, nicht
+  über ganze Berufe.[^gptsaregpts]
 - McKinsey schätzt, dass bis 2030 **rund 30 % der heute geleisteten Arbeitsstunden
   in den USA automatisierbar sein könnten** — wiederum mit grosser Spannweite.[^mckinsey]
 - Der **WEF Future of Jobs Report 2025** (Januar 2025) erwartet bis 2030 weltweit
@@ -319,8 +322,14 @@ diese Daten *nicht* leisten können.
 [^goldman]: Hatzius, J., Briggs, J., Kodnani, D., Pierdomenico, G. (2023):
     *The Potentially Large Effects of Artificial Intelligence on Economic Growth.*
     Goldman Sachs Economics Research, 26. März 2023. — Kernaussage:
-    «up to 300 million full-time jobs globally could be exposed to automation by AI».
-    Exposition ≠ Wegfall.
+    «up to 300 million full-time jobs globally could be exposed to automation by
+    AI». In der medialen Rezeption wurde «exponiert» häufig zu «ersetzt»,
+    «vernichtet» oder «gefährdet» verkürzt — siehe etwa Berliner Zeitung
+    («Goldman Sachs: 300 Millionen Angestellte könnten durch KI ersetzt werden»,
+    <https://www.berliner-zeitung.de/wirtschaft-verantwortung/goldman-sachs-ki-kunstliche-intelligenz-koennte-300-millionen-jobs-kosten-li.332935>),
+    inside-it.ch («Killt ChatGPT 300 Millionen Arbeitsplätze?»,
+    <https://www.inside-it.ch/killt-chatgpt-300-millionen-arbeitsplaetze-20230330>)
+    oder OnlineMarketing.de («Studie: 300 Millionen Jobs durch KI gefährdet»).
 
 [^gptsaregpts]: Eloundou, T., Manning, S., Mishkin, P., Rock, D. (2023):
     *GPTs are GPTs: An Early Look at the Labor Market Impact Potential of Large

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -13,10 +13,19 @@ description: >
 ## Warum wir endlich eigene Zahlen brauchen
 
 Seit dem Aufstieg generativer KI füllt sich die Debatte über die Zukunft der Arbeit
-mit grossen Zahlen und noch grösseren Schlagzeilen: «300 Millionen Jobs gefährdet»,
-«80 % der Berufe betroffen», «das Ende der Bürotätigkeit». Die Studien dahinter sind
-oft seriös — aber sie haben ein gemeinsames Problem: Sie wurden für den **US-Arbeitsmarkt**
-geschrieben.
+mit grossen Zahlen und noch grösseren Schlagzeilen. Bei näherer Betrachtung sind
+diese Zahlen meist präziser — und vorsichtiger — formuliert, als sie in den
+Medien ankommen:
+
+- Goldman Sachs schreibt von «bis zu **300 Millionen weltweit *exponierten*
+  Vollzeitstellen**» — nicht von 300 Millionen wegfallenden Jobs.[^goldman]
+- Eloundou et al. (OpenAI / University of Pennsylvania) zeigen, dass rund
+  **80 % der US-Beschäftigten in mindestens 10 % ihrer Aufgaben** durch grosse
+  Sprachmodelle berührt sein könnten — also kein «80 % der Berufe gehen weg».[^gptsaregpts]
+- McKinsey schätzt, dass bis 2030 **rund 30 % der heute geleisteten Arbeitsstunden
+  in den USA automatisierbar sein könnten** — wiederum mit grosser Spannweite.[^mckinsey]
+
+Was diesen Studien gemeinsam ist: Sie wurden für den **US-Arbeitsmarkt** gerechnet.
 
 Wer in der Schweiz arbeitet, lebt in einer anderen Wirtschaft. Andere Branchenstruktur.
 Andere Lohnniveaus. Ein duales Bildungssystem mit EFZ und Höherer Berufsbildung, das in
@@ -66,30 +75,37 @@ KI-Einführung ist nicht nur eine technische Frage, sondern eine regulatorische.
 auch hier gilt: Was in den USA möglich ist, ist in der Schweiz nicht automatisch erlaubt
 — und umgekehrt.
 
-- Die Schweiz übernimmt den **EU AI Act nicht direkt**, ist über ihre Lieferketten und
-  Marktzugänge aber faktisch davon betroffen. Wie und wann der Bund eigene Regeln
-  schafft, ist offen.
-- Das **revidierte DSG** stellt für viele KI-Anwendungen — insbesondere für
-  Profiling, automatisierte Einzelfallentscheidungen und Personaldaten — Anforderungen,
-  die das Tempo der Einführung beeinflussen.
-- In regulierten Branchen wie **Banken, Versicherungen und Gesundheitswesen** kommen
-  sektorspezifische Aufsichtsregeln (FINMA, Swissmedic, kantonale Gesundheitsbehörden)
-  hinzu, die den Einsatz generativer KI an klare Bedingungen knüpfen.
-- Die Schweizer **Sozialpartnerschaft** und die Rolle der Gewerkschaften bei
-  Gesamtarbeitsverträgen bedeuten, dass Automatisierungsschritte oft verhandelt
-  werden — nicht im Stillen entschieden.
+- Die Schweiz übernimmt den **[EU AI Act][eu-ai-act]** (Verordnung 2024/1689,
+  in Kraft seit 1. August 2024) nicht direkt — ist über Lieferketten und
+  Marktzugang aber faktisch davon betroffen. Der Bundesrat hat eine eigene
+  KI-Regulierung 2025 in Auftrag gegeben; das konkrete Schweizer Regelwerk steht
+  noch aus.[^bundesrat-ki]
+- Das **[revidierte Datenschutzgesetz][revdsg]** (revDSG, in Kraft seit 1. September
+  2023) stellt für viele KI-Anwendungen Anforderungen — insbesondere Art. 5 lit. f/g
+  zum Profiling und Art. 21 zur automatisierten Einzelentscheidung. Das beeinflusst
+  Tempo und Form der Einführung.
+- In regulierten Branchen kommen sektorspezifische Aufsichtsregeln hinzu: die
+  [FINMA][finma] für Finanzdienstleister, [Swissmedic][swissmedic] für Medizinprodukte,
+  und die kantonalen Gesundheitsbehörden im Spitalwesen.
+- Die Schweizer **Sozialpartnerschaft** und Gesamtarbeitsverträge führen dazu, dass
+  Automatisierungsschritte in vielen Branchen verhandelt und nicht einseitig
+  entschieden werden.[^seco-sozialpartnerschaft]
 
 Ein Beruf mit hohem technischem Expositionsscore kann deshalb in der Schweiz langsamer,
 anders oder gar nicht von KI verändert werden, weil rechtliche und sozialpartnerschaftliche
 Leitplanken im Weg stehen. Das Tool kann diese Faktoren nicht modellieren — aber wer
 seine Ergebnisse interpretiert, sollte sie mitdenken.
 
-### 4. Vorhandene Studien sind nicht öffentlich nachvollziehbar
+### 4. Detaildaten und Reproduzierbarkeit fehlen häufig
 
-Wer auf eine McKinsey- oder OECD-Studie verweist, bekommt am Ende eine Grafik. Was er
-nicht bekommt: die Daten, die Methodik im Detail, eine Möglichkeit, die Annahmen zu
-hinterfragen. Genau diese Nachvollziehbarkeit ist aber die Voraussetzung dafür, dass
-Politik, Bildungseinrichtungen und Betroffene fundierte Entscheidungen treffen können.
+McKinsey, OECD und das ILO-Arbeitsmarktteam dokumentieren ihre Methodik in der Regel
+in technischen Anhängen oder Working Papers — das ist anzuerkennen.[^mckinsey] [^oecd]
+[^ilo] Was in der Praxis aber häufig fehlt, ist die Ebene darunter: die **Bewertung
+pro einzelner Berufsgruppe** in maschinenlesbarer Form, die genauen Coding-Entscheide
+und reproduzierbarer Code. Damit bleibt es schwierig, einen einzelnen Beruf
+nachzurechnen oder die Annahmen für den eigenen Kontext zu hinterfragen — gerade
+diese Ebene ist es aber, die für Berufsberatung, Branchenverbände und Betroffene
+relevant ist.
 
 ---
 
@@ -101,13 +117,16 @@ einer öffentlich dokumentierten Methodik. Der Score misst, wie stark sich die
 wann der Beruf tatsächlich verändert wird.
 
 1. **Datengrundlage:** 204 Berufe aus der Schweizerischen Arbeitskräfteerhebung
-   (BFS SAKE 2024), angereichert mit offiziellen Berufsbeschreibungen aus der
-   europäischen ESCO-Klassifikation und Schweizer Lohndaten (BFS LSE 2022).
+   ([BFS SAKE 2024][bfs-sake]), angereichert mit offiziellen Berufsbeschreibungen
+   aus der europäischen [ESCO-Klassifikation][esco] und Schweizer Lohndaten
+   ([BFS LSE 2022][bfs-lse]).
 
 2. **Bewertung durch ein KI-Sprachmodell** (Claude Sonnet) entlang von fünf Kriterien:
    digitaler Output, Wiederholbarkeit, physische Präsenz, Kreativität und soziale
-   Interaktion. Die Methodik orientiert sich an Andrej Karpathys und Michael Webbs
-   Arbeit zur Automatisierungsexposition.
+   Interaktion. Die Auswahl der Kriterien orientiert sich an Michael Webbs Arbeit
+   zur Automatisierungsexposition über Patente[^webb] sowie an Andrej Karpathys
+   öffentlichen Analysen, welche Aufgabentypen sich für grosse Sprachmodelle
+   eignen.[^karpathy]
 
 3. **Schweiz-spezifische Anpassungen:** Auf den Rohscore werden Korrekturen für
    Branche und Lohnniveau angewendet — basierend auf der Struktur der Schweizer
@@ -178,3 +197,84 @@ diese Daten *nicht* leisten können.
 **👉 [Tool öffnen](https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz)**
 &nbsp;·&nbsp;
 **[Code & Methodik auf GitHub](https://github.com/minigraphx/ki-jobexposition-schweiz)**
+
+---
+
+## Quellen und weiterführende Literatur
+
+### Internationale Studien
+
+[^goldman]: Hatzius, J., Briggs, J., Kodnani, D., Pierdomenico, G. (2023):
+    *The Potentially Large Effects of Artificial Intelligence on Economic Growth.*
+    Goldman Sachs Economics Research, 26. März 2023. — Kernaussage:
+    «up to 300 million full-time jobs globally could be exposed to automation by AI».
+    Exposition ≠ Wegfall.
+
+[^gptsaregpts]: Eloundou, T., Manning, S., Mishkin, P., Rock, D. (2023):
+    *GPTs are GPTs: An Early Look at the Labor Market Impact Potential of Large
+    Language Models.* arXiv:2303.10130. <https://arxiv.org/abs/2303.10130> —
+    Kernbefund: «around 80 % of the U.S. workforce could have at least 10 % of
+    their work tasks affected by the introduction of LLMs».
+
+[^mckinsey]: McKinsey Global Institute (2023): *Generative AI and the future of
+    work in America.* Juli 2023. <https://www.mckinsey.com/mgi> — schätzt, dass
+    bis 2030 rund 30 % der heute geleisteten Arbeitsstunden in den USA
+    automatisierbar sein könnten. Methodik wird im technischen Anhang beschrieben.
+
+[^oecd]: OECD (2023): *OECD Employment Outlook 2023 — Artificial Intelligence
+    and the Labour Market.* <https://www.oecd.org/employment-outlook/> — sowie
+    Nedelkoska, L., Quintini, G. (2018): *Automation, skills use and training.*
+    OECD Social, Employment and Migration Working Papers No. 202.
+
+[^ilo]: International Labour Organization (2023): *Generative AI and Jobs: A
+    global analysis of potential effects on job quantity and quality.*
+    ILO Working Paper 96. <https://www.ilo.org/publications>
+
+[^webb]: Webb, M. (2020): *The Impact of Artificial Intelligence on the Labor
+    Market.* Stanford Working Paper, SSRN.
+    <https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3482150>
+
+[^karpathy]: Andrej Karpathy: öffentliche Vorträge und Essays zur Frage,
+    welche Aufgabentypen für grosse Sprachmodelle geeignet sind, u. a.
+    «Intro to Large Language Models» (November 2023). Eine begutachtete
+    akademische Publikation existiert hierzu nicht — das Tool übernimmt die
+    strukturierende Idee, nicht eine peer-reviewed Methodik.
+
+### Rechtliche Grundlagen
+
+[^bundesrat-ki]: Bundesrat (2025): Auftrag für eine sektorspezifische KI-
+    Regulierung in der Schweiz, basierend auf dem Bericht «Übersicht KI-
+    Regulierungsansätze und mögliches Vorgehen für die Schweiz» (BAKOM, 2024).
+    <https://www.bakom.admin.ch>
+
+[^seco-sozialpartnerschaft]: SECO — Staatssekretariat für Wirtschaft:
+    *Sozialpartnerschaft in der Schweiz.* <https://www.seco.admin.ch>
+
+### Schweizer Datenquellen
+
+[bfs-sake]: https://www.bfs.admin.ch/bfs/de/home/statistiken/arbeit-erwerb/erhebungen/sake.html
+    "Schweizerische Arbeitskräfteerhebung (SAKE), Bundesamt für Statistik"
+[bfs-lse]: https://www.bfs.admin.ch/bfs/de/home/statistiken/arbeit-erwerb/loehne-erwerbseinkommen-arbeitskosten/lohnniveau-schweiz/lohnstrukturerhebung.html
+    "Lohnstrukturerhebung (LSE) 2022, Bundesamt für Statistik"
+[esco]: https://esco.ec.europa.eu/de
+    "European Skills, Competences, Qualifications and Occupations, Europäische Kommission"
+
+### Weitere Verweise im Text
+
+[eu-ai-act]: https://eur-lex.europa.eu/eli/reg/2024/1689/oj
+    "Verordnung (EU) 2024/1689 – AI Act"
+[revdsg]: https://www.fedlex.admin.ch/eli/cc/2022/491/de
+    "Bundesgesetz über den Datenschutz (revDSG), in Kraft seit 1. September 2023"
+[finma]: https://www.finma.ch
+    "Eidgenössische Finanzmarktaufsicht FINMA"
+[swissmedic]: https://www.swissmedic.ch
+    "Swissmedic – Schweizerisches Heilmittelinstitut"
+
+### Hinweis zu Interpretationen
+
+Mehrere Aussagen zu Schweizer Spezifika — etwa zur Wirkung des EFZ-Systems, zur
+ICT-Komplementarität oder zur demografischen Lage in Pflege und Gesundheitswesen —
+sind plausible Interpretationen der allgemein verfügbaren Datenlage (BFS, OBSAN,
+SECO), aber nicht Ergebnis einer eigenen empirischen Untersuchung. Wer einzelne
+Punkte vertieft prüfen will, findet bei den jeweiligen Bundesämtern detaillierte
+Statistiken.

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -3,9 +3,9 @@ title: "Welche Schweizer Berufe trifft die KI-Welle? Warum wir endlich eigene Za
 date: 2026-04-26
 tags: [KI, Arbeitsmarkt, Schweiz, Datenanalyse, Automatisierung]
 description: >
-  Generative KI verändert die Arbeitswelt schneller, als die Statistik nachkommt — und fast
-  alle bekannten Studien beziehen sich auf die USA. Höchste Zeit für eine datengetriebene
-  Analyse, die den Schweizer Arbeitsmarkt ernst nimmt.
+  Generative KI verändert die Arbeitswelt — doch fast alle bekannten Studien beziehen
+  sich auf die USA. Ein Versuch, die Diskussion mit Schweizer Daten und Schweizer
+  Rahmenbedingungen zu unterfüttern. Bewusst als Diskussionsgrundlage, nicht als Prognose.
 ---
 
 # Welche Schweizer Berufe trifft die KI-Welle?
@@ -25,12 +25,14 @@ in Schweizer Medien zitiert, als wäre der Coiffeur in Bern dieselbe statistisch
 wie ein *hairdresser* in Houston.
 
 Genau hier setzt **[KI-Jobexposition Schweiz](https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz)**
-an — ein offenes Tool, das für **204 Schweizer Berufe** transparent zeigt, wie stark sie
-durch generative KI exponiert sind.
+an — ein offenes Tool, das für **204 Schweizer Berufe** einen nachvollziehbaren
+Anhaltspunkt liefert, wie stark einzelne Tätigkeiten durch generative KI exponiert
+sein *könnten*. Es ist ausdrücklich keine Prognose darüber, welche Jobs verschwinden
+werden, sondern eine Diskussionsgrundlage.
 
 ---
 
-## Die Problematik in drei Punkten
+## Die Problematik in vier Punkten
 
 ### 1. Niemand spricht über *konkrete* Berufe
 
@@ -42,21 +44,47 @@ brauchen eine Antwort auf die Frage: **«Wie sieht es bei *meinem* Beruf aus?»*
 
 ### 2. Die Schweizer Wirtschaft folgt nicht dem US-Drehbuch
 
-Ein paar Beispiele, die die nationalen Unterschiede deutlich machen:
+Ein paar Beispiele, an denen sich die strukturellen Unterschiede zeigen:
 
-- Der Schweizer **Finanzsektor** ist überdurchschnittlich gross und überdurchschnittlich
-  digital — was die KI-Exposition tendenziell erhöht.
-- **ICT-Berufe** sind in der Schweiz nicht «am stärksten betroffen», wie oft behauptet —
-  sie sind selbst die Treiber der Automatisierung und werden eher komplementär als
-  ersetzend.
-- Im **Gesundheitswesen** und in der **Pflege** schlägt der demografische Druck stärker
-  als die Automatisierung — hier herrscht Personalmangel, nicht Überfluss.
-- Das **EFZ-System** mit seiner engen Verzahnung von Theorie und Praxis schützt viele
-  Berufe, die in den USA als rein «kognitiv» klassifiziert würden.
+- Der Schweizer **Finanzsektor** ist überdurchschnittlich gross und stark digitalisiert —
+  was die KI-Exposition tendenziell erhöhen dürfte.
+- Bei **ICT-Berufen** ist die häufige These «am stärksten betroffen» mindestens
+  diskussionswürdig: Vieles deutet darauf hin, dass sie eher komplementär zur KI
+  arbeiten als von ihr ersetzt zu werden — gesichert ist das nicht.
+- Im **Gesundheitswesen** und in der **Pflege** dominiert in der Schweiz der demografische
+  Druck. Personalmangel und Knappheit sprechen dafür, dass Automatisierung dort eher
+  entlastet als verdrängt — die konkrete Wirkung bleibt offen.
+- Das **EFZ-System** mit seiner engen Verzahnung von Theorie und Praxis dürfte einige
+  Berufe abfedern, die in rein «kognitiven» US-Klassifikationen schlechter wegkommen.
 
-Diese Differenzen sind nicht kosmetisch. Sie verändern das Ranking ganzer Berufsgruppen.
+Diese Unterschiede sollten kein Detail sein, das in der Diskussion verloren geht — sie
+können das Bild für einzelne Berufsgruppen spürbar verschieben.
 
-### 3. Vorhandene Studien sind nicht öffentlich nachvollziehbar
+### 3. Die rechtlichen Rahmenbedingungen sind andere
+
+KI-Einführung ist nicht nur eine technische Frage, sondern eine regulatorische. Und
+auch hier gilt: Was in den USA möglich ist, ist in der Schweiz nicht automatisch erlaubt
+— und umgekehrt.
+
+- Die Schweiz übernimmt den **EU AI Act nicht direkt**, ist über ihre Lieferketten und
+  Marktzugänge aber faktisch davon betroffen. Wie und wann der Bund eigene Regeln
+  schafft, ist offen.
+- Das **revidierte DSG** stellt für viele KI-Anwendungen — insbesondere für
+  Profiling, automatisierte Einzelfallentscheidungen und Personaldaten — Anforderungen,
+  die das Tempo der Einführung beeinflussen.
+- In regulierten Branchen wie **Banken, Versicherungen und Gesundheitswesen** kommen
+  sektorspezifische Aufsichtsregeln (FINMA, Swissmedic, kantonale Gesundheitsbehörden)
+  hinzu, die den Einsatz generativer KI an klare Bedingungen knüpfen.
+- Die Schweizer **Sozialpartnerschaft** und die Rolle der Gewerkschaften bei
+  Gesamtarbeitsverträgen bedeuten, dass Automatisierungsschritte oft verhandelt
+  werden — nicht im Stillen entschieden.
+
+Ein Beruf mit hohem technischem Expositionsscore kann deshalb in der Schweiz langsamer,
+anders oder gar nicht von KI verändert werden, weil rechtliche und sozialpartnerschaftliche
+Leitplanken im Weg stehen. Das Tool kann diese Faktoren nicht modellieren — aber wer
+seine Ergebnisse interpretiert, sollte sie mitdenken.
+
+### 4. Vorhandene Studien sind nicht öffentlich nachvollziehbar
 
 Wer auf eine McKinsey- oder OECD-Studie verweist, bekommt am Ende eine Grafik. Was er
 nicht bekommt: die Daten, die Methodik im Detail, eine Möglichkeit, die Annahmen zu
@@ -67,8 +95,10 @@ Politik, Bildungseinrichtungen und Betroffene fundierte Entscheidungen treffen k
 
 ## Was das Tool macht
 
-Die Plattform berechnet pro Beruf einen **Expositionsscore von 0 bis 10** — und zwar
-auf Basis einer öffentlich dokumentierten Methodik:
+Die Plattform berechnet pro Beruf einen **Expositionsscore von 0 bis 10** auf Basis
+einer öffentlich dokumentierten Methodik. Der Score misst, wie stark sich die
+*Tätigkeiten* eines Berufs grundsätzlich für generative KI eignen — nicht, ob und
+wann der Beruf tatsächlich verändert wird.
 
 1. **Datengrundlage:** 204 Berufe aus der Schweizerischen Arbeitskräfteerhebung
    (BFS SAKE 2024), angereichert mit offiziellen Berufsbeschreibungen aus der
@@ -95,42 +125,55 @@ einsehen.
 
 ## Was das Tool *nicht* ist
 
-Damit kein falscher Eindruck entsteht: Diese Plattform ist **kein Orakel**. Ein hoher
-Score bedeutet nicht, dass ein Beruf in fünf Jahren verschwindet — er bedeutet, dass
-ein grosser Anteil der heutigen Tätigkeiten technisch automatisierbar ist. Ob diese
-Automatisierung tatsächlich passiert, hängt von Regulierung, Tarifpartnern, Kundennachfrage,
-Arbeitsmarktdynamik und vielen weiteren Faktoren ab.
+Damit kein falscher Eindruck entsteht: Diese Plattform ist **kein Orakel** und keine
+Berufsempfehlung. Ein hoher Score bedeutet nicht, dass ein Beruf in fünf Jahren
+verschwindet — er bedeutet, dass viele der heutigen Tätigkeiten technisch grundsätzlich
+für KI-Unterstützung geeignet sind. Ob, wann und in welcher Form daraus tatsächlich
+Veränderungen am Arbeitsmarkt werden, hängt von Regulierung, Recht, Tarifpartnern,
+Kundennachfrage, Investitionsentscheiden und vielen weiteren Faktoren ab, die das
+Modell nicht kennt.
 
 Auch das KI-Modell, das hinter den Scores steht, hat blinde Flecken. Es kennt keine
 Werkstatt von innen, hat noch nie eine Patientin betreut und versteht den Schweizer
-Föderalismus nur über Textquellen. Deshalb sind alle Ergebnisse mit konkreten Begründungen
-hinterlegt — damit Leserinnen und Leser selbst beurteilen können, ob die Argumentation
-trägt.
+Föderalismus nur über Textquellen. Die Scores sind deshalb mit Begründungen hinterlegt
+— so können Leserinnen und Leser selbst prüfen, ob die Argumentation für ihren Beruf
+trägt, und im Zweifel der eigenen Erfahrung mehr Gewicht geben als dem Wert.
+
+Niemand sollte aufgrund eines Scores eine Berufswahl, eine Kündigung oder eine
+Personalentscheidung treffen. Die Daten sind ein Einstieg in ein Gespräch, kein
+Ersatz dafür.
 
 ---
 
-## Für wen das Tool gemacht ist
+## Für wen das Tool ein Ausgangspunkt sein kann
 
-- **Berufstätige**, die wissen wollen, wie sich ihr Tätigkeitsfeld verändern könnte.
-- **Berufsberater:innen und Lehrpersonen**, die Jugendliche bei der Berufswahl begleiten.
-- **HR und Strategie**, die Personalplanung jenseits von Schlagzeilen betreiben wollen.
-- **Politik und Verbände**, die Weiterbildung, Strukturwandel und Sozialversicherungen
-  evidenzbasiert gestalten müssen.
+- **Berufstätige**, die für sich selbst eine Diskussionsgrundlage suchen, wie sich
+  ihr Tätigkeitsfeld verändern könnte.
+- **Berufsberater:innen und Lehrpersonen**, die Jugendlichen ergänzendes Material zur
+  Berufswahl an die Hand geben wollen — neben den etablierten Quellen.
+- **HR und Strategie**, die ein zusätzliches Datenpuzzlestück für Personalplanung
+  und Weiterbildung suchen.
+- **Politik und Verbände**, die für ihre Diskussionen über Strukturwandel und
+  Weiterbildung neben qualitativen Einschätzungen auch quantitative Anhaltspunkte
+  brauchen.
 - **Journalist:innen und Forschende**, die für ihre Beiträge nachvollziehbare
-  Schweizer Zahlen brauchen.
+  Schweizer Zahlen suchen — inklusive der Möglichkeit, der Methodik zu widersprechen.
 
 ---
 
 ## Ein Anfang, kein Endpunkt
 
-KI-Jobexposition Schweiz ist ein **offenes Projekt**. Die Daten und die Methodik
-sind unter MIT-Lizenz frei verfügbar, der Code ist öffentlich, jeder Score wird mit
-Begründung publiziert. Kritik, Korrekturvorschläge und Branchen-Expertise sind
-ausdrücklich willkommen — über GitHub-Issues oder direkt per Mail.
+KI-Jobexposition Schweiz ist ein **offenes Projekt** und ausdrücklich ein Versuch,
+keine fertige Antwort. Die Daten und die Methodik sind unter MIT-Lizenz frei
+verfügbar, der Code ist öffentlich, jeder Score wird mit Begründung publiziert.
+Wo die Methodik Schwächen hat, sollen sie sichtbar sein — Kritik, Korrekturvorschläge
+und Branchen-Expertise sind ausdrücklich willkommen, über GitHub-Issues oder direkt
+per Mail.
 
 Wir werden uns in den nächsten Jahren intensiv mit der Frage beschäftigen müssen, was
-generative KI mit unserem Arbeitsmarkt macht. Diese Diskussion verdient bessere
-Datenbasis als US-Schlagzeilen.
+generative KI mit unserem Arbeitsmarkt macht. Diese Diskussion verdient eine bessere
+Datenbasis als US-Schlagzeilen — und sie verdient auch ehrlichen Umgang mit dem, was
+diese Daten *nicht* leisten können.
 
 **👉 [Tool öffnen](https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz)**
 &nbsp;·&nbsp;

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -436,9 +436,9 @@ diese Daten *nicht* leisten können.
 
 ### Hinweis zu Interpretationen
 
-Mehrere Aussagen zu Schweizer Spezifika — etwa zur Wirkung des EFZ-Systems, zur
-ICT-Komplementarität oder zur demografischen Lage in Pflege und Gesundheitswesen —
-sind plausible Interpretationen der allgemein verfügbaren Datenlage (BFS, OBSAN,
-SECO), aber nicht Ergebnis einer eigenen empirischen Untersuchung. Wer einzelne
-Punkte vertieft prüfen will, findet bei den jeweiligen Bundesämtern detaillierte
-Statistiken.
+Einige Aussagen zu Schweizer Spezifika — etwa zur Abfederungswirkung des
+EFZ-Systems oder zur Bedeutung des demografischen Drucks im Gesundheitswesen —
+sind plausible Einordnungen der allgemein verfügbaren Datenlage (BFS, Obsan,
+SECO), aber nicht Ergebnis einer eigenen empirischen Untersuchung. Belegte
+Befunde aus der KOF-Studie 2025 und dem PwC AI Jobs Barometer sind mit
+Footnotes gekennzeichnet.

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -439,7 +439,7 @@ diese Daten *nicht* leisten können.
 
 ### Weitere Verweise im Text
 
-[eu-ai-act]: https://eur-lex.europa.eu/eli/reg/2024/1689/oj
+[eu-ai-act]: https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng
     "Verordnung (EU) 2024/1689 – AI Act"
 [revdsg]: https://www.fedlex.admin.ch/eli/cc/2022/491/de
     "Bundesgesetz über den Datenschutz (revDSG), in Kraft seit 1. September 2023"

--- a/blog/ki-jobexposition-schweiz.md
+++ b/blog/ki-jobexposition-schweiz.md
@@ -183,6 +183,37 @@ einsehen.
 
 ---
 
+## Vier Beispiele aus den Daten
+
+Vier von 204 Berufen — als Eindruck, wie konkret die Bewertung wird:
+
+**Stark exponiert**
+
+- **Sachbearbeiter/in Buchhaltung** — Score 8.5, Zeitrahmen 3–5 Jahre. ERP-Systeme
+  wie Abacus, SAP und Bexio sowie KI-gestützte Belegerfassung automatisieren in
+  Schweizer Unternehmen bereits einen grossen Teil der Fakturierung; manueller
+  Aufwand bleibt vor allem für Ausnahmefälle und Kundenkommunikation.
+- **Übersetzer:innen, Dolmetscher:innen und Linguist:innen** — Score 7.3,
+  Zeitrahmen 1–2 Jahre. DeepL und LLM-basierte Tools übernehmen Standardtexte
+  und technische Übersetzungen; literarische, juristische und kulturell nuancierte
+  Texte sowie das Dolmetschen bleiben menschliche Domänen.
+
+**Schwach exponiert**
+
+- **Coiffeur/Coiffeuse EFZ** — Score 1.6, Zeitrahmen über 10 Jahre. Manuelle
+  Geschicklichkeit, direkter Körperkontakt und eine vertrauensbasierte
+  Kundenbeziehung sind für KI extrem schwer zugänglich. KI-Stilberatungs-Apps
+  können die Beratungsphase höchstens ergänzen.
+- **Diplomierte Pflegefachperson** — Score 1.8, Zeitrahmen 5–10 Jahre,
+  rund **130'000 Beschäftigte**. Körperlich-empathische Patientenbetreuung lässt
+  sich nicht automatisieren; KI entlastet eher Dokumentation und Pflegeplanung
+  — was angesichts des Schweizer Fachkräftemangels willkommen ist.
+
+Den vollen Score-Aufbau und die Begründung pro Beruf zeigt die
+[Berufssuche im Tool](https://huggingface.co/spaces/AndyWHV/ki-jobexposition-schweiz).
+
+---
+
 ## Was das Tool *nicht* ist
 
 Damit kein falscher Eindruck entsteht: Diese Plattform ist **kein Orakel** und keine


### PR DESCRIPTION
## Summary

Neuer Blogpost unter `blog/ki-jobexposition-schweiz.md`, gedacht zur Veröffentlichung auf der eigenen Webseite.

Der Text fokussiert sich auf die **Problematik**, die das Tool adressiert:

- US-zentrierte KI-Arbeitsmarktstudien werden in Schweizer Medien unverändert übernommen
- Es fehlen Daten zu *konkreten* Berufen — nicht nur zu abstrakten Kategorien
- Schweizer Spezifika (Branchenstruktur, Lohnniveau, EFZ-System) werden in internationalen Studien nicht abgebildet
- Bestehende Studien sind nicht öffentlich nachvollziehbar

Anschliessend wird die Methodik, die Visualisierung sowie die Zielgruppen kompakt beschrieben — und ehrlich dokumentiert, was das Tool *nicht* leisten kann.

## Test plan

- [ ] Markdown im Browser/CMS-Vorschau prüfen (Frontmatter, Links, Headings)
- [ ] Links zu HuggingFace Space und GitHub-Repo prüfen
- [ ] Tonalität & Länge mit eigenem Blog-Stil abgleichen
- [ ] Optional: kürzere Twitter/LinkedIn-Variante daraus ableiten

https://claude.ai/code/session_01DNXbnU5ZZTVyhUtBg4sAH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNXbnU5ZZTVyhUtBg4sAH2)_